### PR TITLE
Adjust waypoint visibility zoom thresholds

### DIFF
--- a/client/src/data/waypoints.test.ts
+++ b/client/src/data/waypoints.test.ts
@@ -74,20 +74,20 @@ describe('getWaypointCoordinates', () => {
 });
 
 describe('getVisibilityTier', () => {
-  it('returns major for zoom < 0.8', () => {
-    expect(getVisibilityTier(0.5)).toBe('major');
-    expect(getVisibilityTier(0.79)).toBe('major');
+  it('returns major for zoom < 0.5', () => {
+    expect(getVisibilityTier(0.2)).toBe('major');
+    expect(getVisibilityTier(0.49)).toBe('major');
   });
 
-  it('returns expanded for zoom 0.8 - 1.69', () => {
+  it('returns expanded for zoom 0.5 - 1.09', () => {
+    expect(getVisibilityTier(0.5)).toBe('expanded');
     expect(getVisibilityTier(0.8)).toBe('expanded');
     expect(getVisibilityTier(1.0)).toBe('expanded');
-    expect(getVisibilityTier(1.5)).toBe('expanded');
-    expect(getVisibilityTier(1.69)).toBe('expanded');
+    expect(getVisibilityTier(1.09)).toBe('expanded');
   });
 
-  it('returns all for zoom >= 1.7', () => {
-    expect(getVisibilityTier(1.7)).toBe('all');
+  it('returns all for zoom >= 1.1', () => {
+    expect(getVisibilityTier(1.1)).toBe('all');
     expect(getVisibilityTier(2.0)).toBe('all');
     expect(getVisibilityTier(3.0)).toBe('all');
   });

--- a/client/src/data/waypoints.ts
+++ b/client/src/data/waypoints.ts
@@ -53,15 +53,15 @@ export function getWaypointCoordinates(
 /**
  * Determine waypoint visibility tier based on zoom level.
  *
- * - Low zoom (< 0.8): only major waypoints (special IS NOT NULL).
- * - Medium zoom (0.8 - 1.7): major + every 3rd non-major.
- * - High zoom (≥ 1.7): all waypoints.
+ * - Low zoom (< 0.5): only major waypoints (special IS NOT NULL).
+ * - Medium zoom (0.5 - 1.1): major + every 3rd non-major.
+ * - High zoom (≥ 1.1): all waypoints.
  */
 export type VisibilityTier = 'major' | 'expanded' | 'all';
 
 export function getVisibilityTier(zoomLevel: number): VisibilityTier {
-  if (zoomLevel < 0.8) return 'major';
-  if (zoomLevel < 1.7) return 'expanded';
+  if (zoomLevel < 0.5) return 'major';
+  if (zoomLevel < 1.1) return 'expanded';
   return 'all';
 }
 


### PR DESCRIPTION
Change visibility tier breakpoints in waypoints.ts and update tests accordingly. The low/medium/high thresholds were adjusted from <0.8 / <1.7 / ≥1.7 to <0.5 / <1.1 / ≥1.1 (major, expanded, all). Updated JSDoc, getVisibilityTier implementation, and waypoints tests to match the new zoom ranges.