### PR TITLE
feat: Implement Gandalf's Absence Arc for narrative re-engagement notifications

### DIFF
--- a/_bmad-output/implementation-artifacts/11-1-web-push-api-infrastructure.md
+++ b/_bmad-output/implementation-artifacts/11-1-web-push-api-infrastructure.md
@@ -1,0 +1,281 @@
+# Story 11.1: Web Push API Infrastructure
+
+Status: ready-for-dev
+
+## Story
+
+As a user,
+I want to be able to opt-in to push notifications from the app,
+so that I can receive timely walking reminders and engagement nudges.
+
+## Acceptance Criteria
+
+1. **Given** the app has no push notification capability,
+   **When** the Web Push infrastructure is implemented,
+   **Then** VAPID key pair is generated and stored as Worker secrets (`VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT`).
+
+2. **Given** the database has no push subscription storage,
+   **When** migration `0126_create_push_subscriptions.sql` is applied,
+   **Then** a `push_subscriptions` table exists with columns: `id` (INTEGER PK), `user_id` (INTEGER FK → users.id ON DELETE CASCADE), `endpoint` (TEXT UNIQUE NOT NULL), `keys_p256dh` (TEXT NOT NULL), `keys_auth` (TEXT NOT NULL), `created_at` (TEXT DEFAULT CURRENT_TIMESTAMP), `last_used_at` (TEXT).
+
+3. **Given** the database has no notification preferences storage,
+   **When** migration `0127_add_notifications_enabled.sql` is applied,
+   **Then** the `users` table has a new `notifications_enabled` column (INTEGER DEFAULT 1 — enabled by default).
+
+4. **Given** an authenticated user wants to subscribe to push notifications,
+   **When** `POST /api/push/subscribe` is called with body `{ endpoint, keys: { p256dh, auth } }`,
+   **Then** the subscription is upserted by endpoint for the authenticated user and returns `{ status: 'success' }`.
+
+5. **Given** an authenticated user wants to unsubscribe from push notifications on the current device,
+   **When** `DELETE /api/push/subscribe` is called with body `{ endpoint }`,
+   **Then** the matching subscription is removed and returns `{ status: 'success' }`.
+
+6. **Given** an authenticated user wants to check their push notification status,
+   **When** `GET /api/push/status` is called,
+   **Then** it returns `{ status: 'success', data: { hasSubscriptions: boolean, subscriptionCount: number, notificationsEnabled: boolean } }`.
+
+7. **Given** an authenticated user wants to toggle their global notification preference,
+   **When** `PUT /api/push/settings` is called with body `{ notificationsEnabled: boolean }`,
+   **Then** the `users.notifications_enabled` column is updated and returns `{ status: 'success' }`.
+   **And** this controls whether cron jobs / scheduled workers send notifications to this user, but does NOT affect the browser push permission grants or stored subscriptions.
+
+8. **Given** the client needs to register for push,
+   **When** the `PushPermissionIsland` Preact component renders on the profile/settings page,
+   **Then** it checks `'PushManager' in window` and `'Notification' in window` for browser support,
+   **And** shows current permission state and a toggle to enable/disable notifications globally,
+   **And** on "Enable" click: calls `Notification.requestPermission()`, then on `'granted'` subscribes via `serviceWorkerRegistration.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey })` with the VAPID public key,
+   **And** sends the resulting subscription to `POST /api/push/subscribe`,
+   **And** if the user uses multiple devices, each device must independently grant permission, but the global enable/disable toggle affects all devices.
+
+9. **Given** the Service Worker receives a `push` event,
+   **When** the push payload is parsed as JSON `{ title, body, url, icon? }`,
+   **Then** `self.registration.showNotification(title, { body, icon, data: { url } })` is called.
+
+10. **Given** the user clicks a push notification,
+    **When** the `notificationclick` event fires in the Service Worker,
+    **Then** the notification closes, and the app opens to `event.notification.data.url` (or `/journey` as fallback).
+
+11. **Given** a push send attempt receives HTTP 404 or 410 (Gone/Not Found) from the push service,
+    **When** the `sendPushNotification` utility processes the response,
+    **Then** the expired/invalid subscription is automatically deleted from `push_subscriptions`.
+
+12. **Given** any push API endpoint is called without authentication,
+    **When** the request lacks a valid `Authorization: Bearer <token>` header,
+    **Then** a 401 response is returned.
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Database migrations (AC: #1, #2, #3)
+  - [ ] 1.1: Create `migrations/0126_create_push_subscriptions.sql` with `push_subscriptions` table
+  - [ ] 1.2: Create `migrations/0127_add_notifications_enabled.sql` adding `notifications_enabled` column to `users`
+  - [ ] 1.3: Update `docs/data-models.md` with new table and column
+
+- [ ] Task 2: VAPID key generation and secrets setup (AC: #1)
+  - [ ] 2.1: Generate VAPID key pair using `npx web-push generate-vapid-keys`
+  - [ ] 2.2: Store keys as Wrangler secrets: `npx wrangler secret put VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT` (should be `mailto:` URI)
+  - [ ] 2.3: Update `worker-configuration.d.ts` to declare `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT` on the `Env` interface
+  - [ ] 2.4: Add a `GET /api/push/vapid-key` public endpoint that returns the VAPID public key (needed by client for `pushManager.subscribe()`)
+
+- [ ] Task 3: Push utility module — `src/push-utils.ts` (AC: #11)
+  - [ ] 3.1: Implement `sendPushNotification(db, endpoint, keys, payload, env)` — constructs VAPID JWT, encrypts payload per RFC 8291/8188, POSTs to subscription endpoint
+  - [ ] 3.2: Implement `sendPushToUser(db, userId, payload, env)` — queries all active subscriptions for user where `users.notifications_enabled = 1`, calls `sendPushNotification` for each, cleans up 404/410 responses
+  - [ ] 3.3: Implement `cleanupExpiredSubscription(db, endpoint)` — deletes subscription by endpoint
+  - [ ] 3.4: Define `PushPayload` interface: `{ title: string; body: string; url?: string; icon?: string }`
+
+- [ ] Task 4: Push API handlers — `src/push-handlers.ts` (AC: #4, #5, #6, #7, #12)
+  - [ ] 4.1: `handlePushSubscribe(request, db, body, allowTestAuth)` — validate session, validate body shape, upsert subscription
+  - [ ] 4.2: `handlePushUnsubscribe(request, db, body, allowTestAuth)` — validate session, validate body has `endpoint`, delete matching subscription
+  - [ ] 4.3: `handlePushStatus(request, db, allowTestAuth)` — validate session, query subscription count + `notifications_enabled` flag
+  - [ ] 4.4: `handlePushSettings(request, db, body, allowTestAuth)` — validate session, validate `notificationsEnabled` is boolean, update `users.notifications_enabled`
+  - [ ] 4.5: `handleVapidKey(env)` — public endpoint, returns `{ status: 'success', data: { vapidPublicKey: env.VAPID_PUBLIC_KEY } }`
+
+- [ ] Task 5: Wire routes in `src/index.ts` (AC: #4, #5, #6, #7, #12)
+  - [ ] 5.1: Import push handlers
+  - [ ] 5.2: Add route matching for `POST /api/push/subscribe`, `DELETE /api/push/subscribe`, `GET /api/push/status`, `PUT /api/push/settings`, `GET /api/push/vapid-key`
+  - [ ] 5.3: Update `getAllowedMethods()` for each push endpoint
+  - [ ] 5.4: `GET /api/push/vapid-key` is public (no auth), all others require `validateSession()`
+
+- [ ] Task 6: Service Worker push handlers — `public/sw.js` (AC: #9, #10)
+  - [ ] 6.1: Add `self.addEventListener('push', ...)` — parse `event.data.json()`, call `self.registration.showNotification()`
+  - [ ] 6.2: Add `self.addEventListener('notificationclick', ...)` — close notification, `clients.openWindow(url)` or focus existing tab
+  - [ ] 6.3: Add `self.addEventListener('pushsubscriptionchange', ...)` — re-subscribe and POST new subscription to server (handles browser-side subscription rotation)
+
+- [ ] Task 7: Client-side push utilities — `client/src/utils/push-client.ts` (AC: #8)
+  - [ ] 7.1: `urlBase64ToUint8Array(base64String)` — convert VAPID public key for `applicationServerKey`
+  - [ ] 7.2: `subscribeToPush(sessionToken)` — full subscribe flow: get SW registration, call `pushManager.subscribe()`, POST to API
+  - [ ] 7.3: `unsubscribeFromPush(sessionToken)` — get existing subscription, call `.unsubscribe()`, DELETE from API
+  - [ ] 7.4: `getPushStatus(sessionToken)` — fetch `GET /api/push/status`
+  - [ ] 7.5: `updateNotificationSettings(sessionToken, enabled)` — PUT to `/api/push/settings`
+  - [ ] 7.6: `fetchVapidKey()` — GET `/api/push/vapid-key` (cached after first fetch)
+
+- [ ] Task 8: PushPermission Preact island — `client/src/islands/PushPermissionIsland.tsx` (AC: #8)
+  - [ ] 8.1: Check browser support (`'PushManager' in window`, `'Notification' in window`)
+  - [ ] 8.2: Display current notification permission state (`Notification.permission`)
+  - [ ] 8.3: Global enable/disable toggle — calls `PUT /api/push/settings` (this controls server-side cron delivery for ALL devices, not per-device permission)
+  - [ ] 8.4: "Enable on this device" button — triggers permission request + subscription flow
+  - [ ] 8.5: "Disable on this device" button — unsubscribes this browser's push subscription
+  - [ ] 8.6: Show subscription count ("Enabled on N devices")
+  - [ ] 8.7: Show unsupported browser message gracefully
+  - [ ] 8.8: Read `sessionToken` from `appStore` signals
+  - [ ] 8.9: Register island in `client/src/index.tsx` auto-hydration map
+
+- [ ] Task 9: Integrate into profile/settings page
+  - [ ] 9.1: Add `PushPermissionIsland` mount point (`<div data-island="PushPermissionIsland"></div>`) to the profile page render (`src/renderProfilePage.ts`)
+  - [ ] 9.2: Add CSS for the push permission component in `public/css/profile.css` (or existing stylesheet for profile)
+
+- [ ] Task 10: Tests (AC: all)
+  - [ ] 10.1: Backend tests in `tests/api/push-handlers.test.ts` — subscribe, unsubscribe, status, settings, vapid-key, auth rejection, upsert logic, cleanup
+  - [ ] 10.2: Client unit tests in `client/src/islands/PushPermissionIsland.test.tsx` — all permission states, toggle behavior, browser support detection
+  - [ ] 10.3: Client utility tests in `client/src/utils/push-client.test.ts` — all utility functions, error handling
+  - [ ] 10.4: Service worker push handler tests (if feasible with current test setup — mock `PushEvent` in jest)
+
+## Dev Notes
+
+### Architecture & Patterns
+
+- **Handler pattern**: Follow the established pattern from `src/stats-handlers.ts` / `src/friends-handlers.ts`. Each exported handler receives `(request, db, body?, allowTestAuth?)` and returns a `Response`.
+- **Route wiring**: Add exact routes in `src/index.ts` within the existing `if/else if` chain. Push endpoints are `/api/push/*`. The VAPID key endpoint is public; all others require `validateSession()`.
+- **DB access**: Use `db.read` for SELECT, `db.write` for INSERT/UPDATE/DELETE via the `DbClient` from `src/db.ts`.
+- **Response format**: Use `createSuccessResponse(data)` and `createErrorResponse(message, statusCode)` from `src/validators.ts`.
+- **Auth validation**: `validateSession(request, db, allowTestAuth)` — pattern returns `{ valid: true, userId }` or `{ valid: false, error: Response }`.
+
+### Multi-Device & Global Settings Design
+
+- **Per-device subscriptions**: A user can have multiple rows in `push_subscriptions` — one per device/browser. Each device must independently grant `Notification.requestPermission()` and call `pushManager.subscribe()`.
+- **Global toggle**: The `users.notifications_enabled` column (INTEGER 0/1) controls whether the **server** sends push notifications to the user via cron/scheduled jobs. When disabled, `sendPushToUser()` short-circuits and sends nothing.
+- **Global toggle does NOT**:
+  - Revoke browser-level notification permissions (that's browser-controlled)
+  - Delete push subscriptions from the database (so re-enabling is instant)
+  - Affect the `Notification.permission` state on any device
+- **Re-enabling**: When the user toggles notifications back on, all existing subscriptions immediately become active for delivery again — no need to re-grant permissions on each device.
+
+### Web Push Encryption (RFC 8291 + RFC 8188)
+
+- **CRITICAL**: Web Push payloads MUST be encrypted. The `web-push` npm library handles this, BUT it uses Node.js crypto APIs that are NOT available in Cloudflare Workers.
+- **Cloudflare Workers approach**: Use the Web Crypto API (`crypto.subtle`) directly to implement:
+  1. ECDH key agreement (using the subscription's `p256dh` key)
+  2. HKDF key derivation
+  3. AES-128-GCM content encryption (RFC 8188)
+  4. VAPID JWT signing (ES256 / ECDSA P-256 with SHA-256)
+- **Alternative**: Use a Workers-compatible library or implement the encryption inline in `src/push-utils.ts`. The encryption logic is ~100 lines. Reference implementations exist for Cloudflare Workers.
+- **VAPID JWT**: Self-signed JWT with `{ aud: <push service origin>, exp: <24h>, sub: <VAPID_SUBJECT> }` signed with the VAPID private key using ES256.
+- **Headers on push POST**: `Authorization: vapid t=<JWT>,k=<VAPID_PUBLIC_KEY_BASE64URL>`, `Content-Encoding: aes128gcm`, `Content-Type: application/octet-stream`, `TTL: 86400`.
+
+### Service Worker Integration
+
+- **File**: `public/sw.js` (vanilla JS, NOT TypeScript)
+- **Existing handlers**: `install`, `activate`, `fetch` (SWR caching), `message` — do NOT modify these.
+- **Add new handlers**:
+  - `push` event: `event.waitUntil(self.registration.showNotification(...))`
+  - `notificationclick` event: `clients.openWindow(url)` or focus existing client
+  - `pushsubscriptionchange` event: re-subscribe and POST new subscription to server
+- **Push payload JSON format**: `{ title: string, body: string, url?: string, icon?: string }`
+- **Default icon**: Use `/img/icon-192.png` or similar app icon if the payload omits `icon`.
+- **Notification click URL**: Default to `/journey` if `url` not in payload.
+
+### Migration Details
+
+- **Next migration number**: `0126` (after existing `0125_add_party_avatar_id.sql`)
+- **0126_create_push_subscriptions.sql**:
+  ```sql
+  CREATE TABLE IF NOT EXISTS push_subscriptions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    endpoint TEXT NOT NULL UNIQUE,
+    keys_p256dh TEXT NOT NULL,
+    keys_auth TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_used_at TEXT
+  );
+  CREATE INDEX idx_push_subscriptions_user_id ON push_subscriptions(user_id);
+  ```
+- **0127_add_notifications_enabled.sql**:
+  ```sql
+  ALTER TABLE users ADD COLUMN notifications_enabled INTEGER NOT NULL DEFAULT 1;
+  ```
+
+### Env / Secrets
+
+- `VAPID_PUBLIC_KEY`: Base64url-encoded public key (safe to expose to client)
+- `VAPID_PRIVATE_KEY`: Base64url-encoded private key (secret, never sent to client)
+- `VAPID_SUBJECT`: `mailto:` URI identifying the application server (e.g., `mailto:admin@wtm.haydencarson.com`)
+- These are Wrangler **secrets** (not vars) — added via `npx wrangler secret put <NAME>`
+- The `worker-configuration.d.ts` `Env` interface must declare: `VAPID_PUBLIC_KEY: string`, `VAPID_PRIVATE_KEY: string`, `VAPID_SUBJECT: string`
+- For local dev, set these in `.dev.vars` (already gitignored)
+
+### Client Island Registration
+
+- Register `PushPermissionIsland` in `client/src/index.tsx` alongside the other 20+ islands.
+- Mount point: `<div id="preact-root" data-island="PushPermissionIsland"></div>` or use a dedicated container in the profile page.
+- Read `sessionToken` from `appStore` signals (`import { sessionToken } from '../stores/appStore'`).
+
+### CSRF / Security
+
+- All push endpoints (except VAPID key) require `Authorization: Bearer <token>` — this is an anti-CSRF mechanism since the token is not sent automatically by the browser.
+- Validate that `endpoint` in subscription requests is a valid HTTPS URL (push service endpoints are always HTTPS).
+- Do NOT log or expose `keys_auth` or `keys_p256dh` values in error messages.
+- The VAPID private key must NEVER appear in client-side code or API responses.
+
+### Testing Considerations
+
+- **Backend**: Mock `db.read`/`db.write` calls. Test upsert behavior (same endpoint, different user = reject; same user, same endpoint = update). Test cleanup on 410.
+- **Client**: Mock `navigator.serviceWorker`, `PushManager`, `Notification` APIs. Test all permission states: `default`, `granted`, `denied`. Test browser support detection.
+- **Service Worker**: If mocking `PushEvent` is complex, document manual testing steps for push event handling.
+- **Test auth**: Use `TEST_MOCK_TOKEN_<username>` pattern like existing tests.
+
+### Project Structure Notes
+
+- New files:
+  - `src/push-handlers.ts` — API route handlers
+  - `src/push-utils.ts` — push notification delivery utility (VAPID JWT + encryption)
+  - `client/src/islands/PushPermissionIsland.tsx` — Preact island
+  - `client/src/utils/push-client.ts` — client-side push utility functions
+  - `tests/api/push-handlers.test.ts` — backend tests
+  - `client/src/islands/PushPermissionIsland.test.tsx` — island tests
+  - `client/src/utils/push-client.test.ts` — utility tests
+  - `migrations/0126_create_push_subscriptions.sql`
+  - `migrations/0127_add_notifications_enabled.sql`
+- Modified files:
+  - `src/index.ts` — route wiring + imports
+  - `worker-configuration.d.ts` — Env interface (VAPID secrets)
+  - `public/sw.js` — push + notificationclick + pushsubscriptionchange handlers
+  - `client/src/index.tsx` — register PushPermissionIsland
+  - `src/renderProfilePage.ts` — add island mount point
+  - `docs/data-models.md` — document new table + column
+  - `docs/api-reference.md` — document new endpoints
+
+### References
+
+- Push subscription management pattern: [Source: docs/architecture.md#Authentication] (follows same validateSession pattern)
+- DB migration convention: [Source: docs/data-models.md] — 0-padded 4-digit, descriptive name
+- Route wiring: [Source: src/index.ts] — matchRoute + if/else chain
+- Handler signature: [Source: src/auth-handlers.ts, src/stats-handlers.ts] — `(request, db, body?, allowTestAuth?)`
+- Response utilities: [Source: src/validators.ts] — `createSuccessResponse`, `createErrorResponse`
+- Service Worker: [Source: public/sw.js] — existing SWR + cache patterns
+- Island registration: [Source: client/src/index.tsx] — auto-hydration map
+- App store: [Source: client/src/stores/appStore.ts] — `sessionToken`, `userId` signals
+- User preferences pattern: [Source: src/auth-handlers.ts#handleUpdatePreferences] — dynamic UPDATE column building
+- Web Push API: https://developer.mozilla.org/en-US/docs/Web/API/Push_API
+- Cloudflare Scheduled Handler: https://developers.cloudflare.com/workers/runtime-apis/handlers/scheduled/
+- RFC 8291 (Web Push Encryption): https://datatracker.ietf.org/doc/html/rfc8291
+- RFC 8188 (Encrypted Content-Encoding): https://datatracker.ietf.org/doc/html/rfc8188
+- RFC 8292 (VAPID): https://datatracker.ietf.org/doc/html/rfc8292
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Opus 4.6 (GitHub Copilot)
+
+### Completion Notes List
+
+- Story created: 2026-04-10
+- Ultimate context engine analysis completed — comprehensive developer guide created
+- Key design decision: Global notifications_enabled toggle on users table controls server-side delivery, NOT per-device browser permissions
+- Key technical constraint: Cloudflare Workers cannot use `web-push` npm library (Node.js crypto) — must implement VAPID JWT + payload encryption using Web Crypto API
+- This story is a P0 blocker for stories 11.2, 11.3, and 11.4
+- No `scheduled()` handler is needed in this story — that comes in Story 11.2 for daily cron notifications
+
+### File List
+
+<!-- To be filled by dev agent -->

--- a/_bmad-output/implementation-artifacts/11-2-one-more-mile-push-notification.md
+++ b/_bmad-output/implementation-artifacts/11-2-one-more-mile-push-notification.md
@@ -170,8 +170,7 @@ export default {
     // ... existing router ...
   },
   async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext): Promise<void> {
-    const db = createDbClient(env.DB);
-    ctx.waitUntil(handleOneMoreMileCron(db, env));
+    ctx.waitUntil(handleOneMoreMileCron(env));
   }
 } satisfies ExportedHandler<Env>;
 ```

--- a/_bmad-output/implementation-artifacts/11-2-one-more-mile-push-notification.md
+++ b/_bmad-output/implementation-artifacts/11-2-one-more-mile-push-notification.md
@@ -1,0 +1,465 @@
+# Story 11.2: "One More Mile" Push Notification
+
+Status: ready-for-dev
+
+## Story
+
+As a user who is close to reaching my next milestone but hasn't walked recently,
+I want to receive a themed push notification reminding me how close I am,
+so that I get a gentle, contextual nudge that motivates me to log a walk and reach my next goal.
+
+## Context & Design Intent
+
+This is NOT a daily spam notification. It is a **targeted, one-time nudge** for users who meet ALL of the following criteria simultaneously:
+
+1. They are **less than 2 km** from their next goal/milestone.
+2. They have **not logged a walk in the past 3 days** (yesterday, the day before, and the day before that — encouraging them to possibly back-fill yesterday's walk).
+3. They have **never been sent a "One More Mile" notification for this specific goal** before.
+4. They have **not completed the full journey** (total distance < final milestone).
+5. They have **notifications enabled globally** (`users.notifications_enabled = 1`).
+6. They have the **"One More Mile" notification type specifically enabled** (`users.one_more_mile_enabled = 1`).
+
+The notification features **multiple themed message variants** for variety — each run randomly selects from a pool of Tolkien-flavoured messages.
+
+## Acceptance Criteria
+
+1. **Given** a user's total distance is within 2 km of their next milestone's distance,
+   **And** they have not logged a walk entry for any of the past 3 days (yesterday, day-before-yesterday, or the day before that),
+   **And** they have never received a "One More Mile" notification for that specific goal before,
+   **And** they have not completed the full journey (i.e., there exists a goal with `distance > totalDistance`),
+   **And** `users.notifications_enabled = 1` (global toggle) **and** `users.one_more_mile_enabled = 1` (feature toggle),
+   **When** the scheduled cron job runs,
+   **Then** a push notification is sent to all of that user's active push subscriptions,
+   **And** the notification payload includes a randomly selected themed message variant,
+   **And** a record is stored in `one_more_mile_sent` to prevent re-sending for the same goal,
+   **And** the notification's click-through URL is `/` (so the app routes to `/journey` or `/map` based on the user's `default_view_map` preference).
+
+2. **Given** a user meets all distance and inactivity criteria,
+   **But** they have already received a "One More Mile" notification for that specific goal,
+   **When** the cron job runs,
+   **Then** no notification is sent for that goal.
+
+3. **Given** a user is within 2 km of their next goal,
+   **But** they logged a walk yesterday, or the day before, or the day before that,
+   **When** the cron job runs,
+   **Then** no notification is sent (user is already active).
+
+4. **Given** a user has completed the entire journey (no remaining goals beyond their total distance),
+   **When** the cron job runs,
+   **Then** no notification is sent.
+
+5. **Given** an authenticated user views the notification settings on their profile,
+   **When** the global notifications toggle is OFF,
+   **Then** the notification settings group is collapsed and individual toggles are hidden.
+
+6. **Given** an authenticated user views the notification settings on their profile,
+   **When** the global notifications toggle is ON,
+   **Then** the settings group expands showing individual notification type toggles,
+   **And** a "One More Mile" toggle is visible with a description explaining the feature,
+   **And** the toggle defaults to ON for new users.
+
+7. **Given** a user toggles the "One More Mile" setting,
+   **When** `PUT /api/push/settings` is called with `{ oneMoreMileEnabled: boolean }`,
+   **Then** `users.one_more_mile_enabled` is updated and the response confirms success.
+
+8. **Given** the cron job runs and sends a notification,
+   **When** the push service returns 404 or 410 (Gone),
+   **Then** the expired subscription is cleaned up (deleted from `push_subscriptions`),
+   **And** the `one_more_mile_sent` record is still written (so the user isn't re-targeted if they re-subscribe).
+
+9. **Given** there are multiple themed message variants,
+   **When** a notification is sent,
+   **Then** the selected variant includes a `title` and `body` that reference the goal name and remaining distance,
+   **And** the variant is randomly chosen from the pool.
+
+10. **Given** the `scheduled()` handler is called,
+    **When** there are many eligible users,
+    **Then** users are processed in batches (page size: 100) to stay within D1 row limits and Worker CPU time.
+
+11. **Given** a user receives a "One More Mile" push notification,
+    **When** the user clicks/taps the notification,
+    **Then** the app opens to `/` (which routes to the user's preferred default view) — if the PWA or a browser tab is already open, it focuses that existing window instead of opening a new one,
+    **And** the notification is dismissed on click.
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Database migration — `one_more_mile_sent` tracking table (AC: #1, #2, #8)
+  - [ ] 1.1: Create `migrations/0128_create_one_more_mile_sent.sql` with `one_more_mile_sent` table: `id` (PK), `user_id` (FK → users ON DELETE CASCADE), `goal_id` (FK → goals ON DELETE CASCADE), `sent_at` (TEXT DEFAULT CURRENT_TIMESTAMP), with `UNIQUE(user_id, goal_id)` constraint
+  - [ ] 1.2: Update `docs/data-models.md` with new table
+
+- [ ] Task 2: Database migration — `one_more_mile_enabled` user preference (AC: #6, #7)
+  - [ ] 2.1: Create `migrations/0129_add_one_more_mile_enabled.sql`: `ALTER TABLE users ADD COLUMN one_more_mile_enabled INTEGER NOT NULL DEFAULT 1;`
+  - [ ] 2.2: Update `docs/data-models.md` with new column
+
+- [ ] Task 3: Themed message variants — `src/push-messages.ts` (AC: #9)
+  - [ ] 3.1: Create `src/push-messages.ts` exporting a `ONE_MORE_MILE_MESSAGES` array of `{ title: string; bodyTemplate: string }` objects
+  - [ ] 3.2: Implement `getOneMoreMileMessage(goalTitle: string, remainingKm: number)` that randomly selects a variant and interpolates `{goalTitle}` and `{remainingKm}` placeholders
+  - [ ] 3.3: Include at least 8 themed message variants (see Dev Notes for examples)
+
+- [ ] Task 4: Cron handler — `src/scheduled-handlers.ts` (AC: #1, #2, #3, #4, #8, #10)
+  - [ ] 4.1: Create `src/scheduled-handlers.ts` with `handleOneMoreMileCron(env: Env)` function
+  - [ ] 4.2: Implement the eligible-user query: join `users`, `progress` (aggregated), `goals`, `push_subscriptions`, filtering by all 6 criteria (< 2 km, no walks in 3 days, not sent for this goal, not completed journey, both toggles enabled, has active subscription)
+  - [ ] 4.3: Process eligible users in batches (100 per query page)
+  - [ ] 4.4: For each eligible user: select random message, call `sendPushToUser()` from `src/push-utils.ts`, insert into `one_more_mile_sent`
+  - [ ] 4.5: Handle `sendPushToUser` failures gracefully — log errors, continue processing remaining users
+  - [ ] 4.6: Clean up expired subscriptions on 404/410 (re-use `cleanupExpiredSubscription` from `push-utils.ts`)
+
+- [ ] Task 5: Wire scheduled handler in `src/index.ts` (AC: #10)
+  - [ ] 5.1: Add `scheduled()` export alongside existing `fetch()` handler
+  - [ ] 5.2: Route to `handleOneMoreMileCron(env)` on cron trigger
+  - [ ] 5.3: Wrap in try/catch with console.error logging
+
+- [ ] Task 6: Update `wrangler.json` with cron trigger (AC: #10)
+  - [ ] 6.1: Add `"triggers": { "crons": ["0 9 * * *"] }` — run daily at 09:00 UTC
+  - [ ] 6.2: Document the cron schedule choice in code comment
+
+- [ ] Task 7: Update push settings API — `src/push-handlers.ts` (AC: #7)
+  - [ ] 7.1: Extend `handlePushSettings` (from Story 11.1) to accept `oneMoreMileEnabled` in addition to `notificationsEnabled`
+  - [ ] 7.2: Update `PUT /api/push/settings` body validation to handle both fields (either or both can be present)
+  - [ ] 7.3: Extend `GET /api/push/status` response to include `oneMoreMileEnabled: boolean`
+
+- [ ] Task 8: Refactor PushPermissionIsland into NotificationSettings group (AC: #5, #6)
+  - [ ] 8.1: Refactor `PushPermissionIsland` (from Story 11.1) to use a collapsible "Notification Settings" group pattern
+  - [ ] 8.2: The global notifications toggle becomes the collapse header — when OFF, group stays collapsed; when ON, group expands to show individual notification type toggles
+  - [ ] 8.3: Add "One More Mile Notifications" toggle inside the expanded group with descriptive text: "Get a nudge when you're close to your next milestone and haven't walked in a few days"
+  - [ ] 8.4: Wire the "One More Mile" toggle to `PUT /api/push/settings` with `{ oneMoreMileEnabled }` 
+  - [ ] 8.5: Load initial state for `oneMoreMileEnabled` from `GET /api/push/status`
+  - [ ] 8.6: Add CSS for the collapsible group in `public/css/profile.css`
+
+- [ ] Task 9: Tests (AC: all)
+  - [ ] 9.1: Backend tests in `tests/api/scheduled-handlers.test.ts`:
+    - Eligible user gets notification (all criteria met)
+    - User with walk in past 3 days is skipped
+    - User already notified for this goal is skipped
+    - User who completed the journey is skipped
+    - User with global notifications off is skipped
+    - User with one_more_mile_enabled off is skipped
+    - Batch processing works correctly
+    - Expired subscription cleanup on 410
+    - Random message selection produces valid output
+  - [ ] 9.2: Backend tests for updated push settings in `tests/api/push-handlers.test.ts`:
+    - `PUT /api/push/settings` with `oneMoreMileEnabled` updates column
+    - `GET /api/push/status` returns `oneMoreMileEnabled` field
+  - [ ] 9.3: Unit tests for message variants in `tests/api/push-messages.test.ts`:
+    - All message templates produce valid strings
+    - `getOneMoreMileMessage()` interpolates goal name and distance correctly
+    - Random selection covers the pool (statistical test optional)
+  - [ ] 9.4: Client tests in `client/src/islands/PushPermissionIsland.test.tsx`:
+    - Collapsible group collapses when global toggle is OFF
+    - Group expands when global toggle is ON
+    - "One More Mile" toggle visible in expanded state
+    - Toggle calls API with correct payload
+
+## Dev Notes
+
+### Architecture & Patterns
+
+- **Handler pattern**: Follow `src/stats-handlers.ts` / `src/friends-handlers.ts`. Each handler receives `(request, db, body?, allowTestAuth?)` and returns a `Response`.
+- **DB access**: Use `db.read` for SELECT, `db.write` for INSERT/UPDATE/DELETE via `DbClient` from `src/db.ts`.
+- **Response format**: Use `createSuccessResponse(data)` and `createErrorResponse(message, statusCode)` from `src/validators.ts`.
+- **Auth validation**: `validateSession(request, db, allowTestAuth)` — returns `{ valid: true, userId }` or `{ valid: false, error: Response }`.
+
+### Scheduled Handler Pattern
+
+The Worker must export a `scheduled()` handler alongside `fetch()`. This is a **new pattern** for this codebase — no scheduled handler exists yet.
+
+```typescript
+// src/index.ts — export pattern
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    // ... existing router ...
+  },
+  async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext): Promise<void> {
+    const db = createDbClient(env.DB);
+    ctx.waitUntil(handleOneMoreMileCron(db, env));
+  }
+} satisfies ExportedHandler<Env>;
+```
+
+**wrangler.json** addition:
+```json
+{
+  "triggers": {
+    "crons": ["0 9 * * *"]
+  }
+}
+```
+
+**Local testing**: `npx wrangler dev --test-scheduled`, then `curl http://localhost:8787/__scheduled?cron=0+9+*+*+*`
+
+### Eligible User Query Strategy
+
+The core query must find users matching ALL criteria in a single efficient query. Here is the recommended approach:
+
+```sql
+-- Step 1: For each user with active push subscriptions + both toggles enabled,
+-- compute their total distance and find their next goal
+WITH user_distances AS (
+  SELECT 
+    u.id AS user_id,
+    COALESCE(SUM(p.distance), 0) AS total_distance
+  FROM users u
+  LEFT JOIN progress p ON p.user_id = u.id
+  WHERE u.notifications_enabled = 1
+    AND u.one_more_mile_enabled = 1
+  GROUP BY u.id
+),
+-- Step 2: Find next goal for each user (first goal with distance > total_distance)
+user_next_goals AS (
+  SELECT 
+    ud.user_id,
+    ud.total_distance,
+    MIN(g.id) AS next_goal_id,
+    MIN(g.distance) AS next_goal_distance,
+    MIN(g.title) AS next_goal_title
+  FROM user_distances ud
+  INNER JOIN goals g ON g.distance > ud.total_distance
+  GROUP BY ud.user_id, ud.total_distance
+),
+-- Step 3: Filter to within 2 km
+close_users AS (
+  SELECT *
+  FROM user_next_goals
+  WHERE (next_goal_distance - total_distance) < 2.0
+)
+SELECT 
+  cu.user_id,
+  cu.total_distance,
+  cu.next_goal_id,
+  cu.next_goal_distance,
+  cu.next_goal_title,
+  (cu.next_goal_distance - cu.total_distance) AS remaining_km
+FROM close_users cu
+-- Must have at least one active push subscription
+WHERE EXISTS (
+  SELECT 1 FROM push_subscriptions ps WHERE ps.user_id = cu.user_id
+)
+-- Must NOT have a walk in the past 3 days
+AND NOT EXISTS (
+  SELECT 1 FROM progress p 
+  WHERE p.user_id = cu.user_id 
+    AND p.date >= date('now', '-3 days')
+)
+-- Must NOT have already been sent a notification for this goal
+AND NOT EXISTS (
+  SELECT 1 FROM one_more_mile_sent oms 
+  WHERE oms.user_id = cu.user_id 
+    AND oms.goal_id = cu.next_goal_id
+)
+LIMIT 100 OFFSET ?;
+```
+
+**Performance notes:**
+- D1 has a 1 MB result size limit per query — batching with LIMIT/OFFSET handles this.
+- The CTE approach avoids N+1 queries. With small user counts (<10k), this is efficient.
+- Index on `push_subscriptions(user_id)` exists from Story 11.1 migration.
+- Consider adding an index on `progress(user_id, date)` if not already present — check existing schema.
+
+### "3 Days" Inactivity Logic
+
+The intent is: the user hasn't walked for 3 consecutive recent days (yesterday, day-before-yesterday, and the day before that). This means:
+- `date('now', '-1 day')` = yesterday
+- `date('now', '-2 days')` = day before yesterday  
+- `date('now', '-3 days')` = 3 days ago
+
+The query `p.date >= date('now', '-3 days')` catches any walk logged on yesterday, the day before, or the day before that. If ANY walk exists in that range, the user is considered "active" and is skipped.
+
+**Why 3 days specifically?** The user wants to encourage back-filling yesterday's walk. If someone walked yesterday but hasn't entered it yet, they have 3 days of buffer before getting nudged. This avoids annoying users who simply log their walks a day or two late.
+
+### Themed Message Variants
+
+Create at least 8 variants. Each has a `title` and `bodyTemplate` with `{goalTitle}` and `{remainingKm}` placeholders. Examples:
+
+```typescript
+export const ONE_MORE_MILE_MESSAGES: ReadonlyArray<{ title: string; bodyTemplate: string }> = [
+  {
+    title: "One More Mile, {goalTitle} Awaits!",
+    bodyTemplate: "You're just {remainingKm} km away from {goalTitle}. Surely a short walk would take you there!"
+  },
+  {
+    title: "The Road Goes Ever On",
+    bodyTemplate: "Only {remainingKm} km to {goalTitle}. Even the smallest step forward can change the journey."
+  },
+  {
+    title: "Don't Stop Now, Traveller!",
+    bodyTemplate: "{goalTitle} is a mere {remainingKm} km ahead. You've come too far to rest now."
+  },
+  {
+    title: "Almost There!",
+    bodyTemplate: "If Samwise can carry Frodo up Mount Doom, you can walk {remainingKm} km to {goalTitle}."
+  },
+  {
+    title: "A Shortcut to {goalTitle}",
+    bodyTemplate: "Just {remainingKm} km remain. Mushrooms optional, but the milestone is within reach!"
+  },
+  {
+    title: "The Eagles Are Coming!",
+    bodyTemplate: "Well, not quite — but {goalTitle} is only {remainingKm} km away. Lace up those boots!"
+  },
+  {
+    title: "Strider's Counsel",
+    bodyTemplate: "\"Not all those who wander are lost.\" And you're only {remainingKm} km from {goalTitle}."
+  },
+  {
+    title: "A Light in the Darkness",
+    bodyTemplate: "{goalTitle} glimmers just {remainingKm} km ahead. One walk is all it takes."
+  }
+];
+```
+
+**Random selection**: Use `Math.floor(Math.random() * messages.length)` — no need for crypto-grade randomness.
+
+**Interpolation**: Simple string replace: `.replace(/{goalTitle}/g, goalTitle).replace(/{remainingKm}/g, remainingKm.toFixed(1))`.
+
+### Notification Settings UI — Collapsible Group Pattern
+
+The existing `PushPermissionIsland` (from Story 11.1) currently has a single global toggle. This story refactors it into a **collapsible notification settings group**:
+
+```
+┌─ Notification Settings ──────────────────┐
+│ 🔔 Push Notifications  [━━━━●] ON       │ ← Global toggle (collapse header)
+│                                           │
+│ ┌─ Notification Types ─────────────────┐ │ ← Revealed when global is ON
+│ │ 📍 One More Mile      [━━━━●] ON    │ │
+│ │   Get a nudge when you're close to   │ │
+│ │   your next milestone.               │ │
+│ └──────────────────────────────────────┘ │
+│                                           │
+│ Enabled on 2 devices                      │
+└───────────────────────────────────────────┘
+```
+
+When global toggle is OFF:
+```
+┌─ Notification Settings ──────────────────┐
+│ 🔔 Push Notifications  [●━━━━] OFF      │ ← Collapsed, no children visible
+└───────────────────────────────────────────┘
+```
+
+**Implementation approach:**
+- Use a Preact state signal `isExpanded` derived from the global `notificationsEnabled` state.
+- When `notificationsEnabled` is false, render only the header toggle.
+- When `notificationsEnabled` is true, expand to show device status + individual notification type toggles.
+- Each notification type toggle calls `PUT /api/push/settings` with the specific field.
+- Animate expand/collapse with CSS `max-height` transition or `details`/`summary` HTML element.
+
+### Migration Details
+
+- **Next migration numbers**: `0128` and `0129` (after Story 11.1's `0126` and `0127`)
+- **0128_create_one_more_mile_sent.sql**:
+  ```sql
+  CREATE TABLE IF NOT EXISTS one_more_mile_sent (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    goal_id INTEGER NOT NULL REFERENCES goals(id) ON DELETE CASCADE,
+    sent_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(user_id, goal_id)
+  );
+  CREATE INDEX idx_one_more_mile_sent_user_goal ON one_more_mile_sent(user_id, goal_id);
+  ```
+- **0129_add_one_more_mile_enabled.sql**:
+  ```sql
+  ALTER TABLE users ADD COLUMN one_more_mile_enabled INTEGER NOT NULL DEFAULT 1;
+  ```
+
+### Push settings API extension
+
+Story 11.1 creates `PUT /api/push/settings` accepting `{ notificationsEnabled }`. This story extends it:
+
+- Accept body: `{ notificationsEnabled?: boolean, oneMoreMileEnabled?: boolean }` — either or both fields.
+- Validate: if `oneMoreMileEnabled` is present, it must be a boolean.
+- Update: build dynamic UPDATE SET clause for only the provided fields (follow the pattern in `handleUpdatePreferences` in `auth-handlers.ts` which dynamically builds column sets).
+- Extend `GET /api/push/status` response to include `oneMoreMileEnabled`.
+
+### Worker `scheduled()` handler — New export pattern
+
+The current `src/index.ts` exports a `default` object with only `fetch`. This must be extended:
+
+```typescript
+export default {
+  async fetch(request, env, ctx) { /* existing */ },
+  async scheduled(event, env, ctx) { /* new */ }
+} satisfies ExportedHandler<Env>;
+```
+
+**Check**: If `src/index.ts` currently uses `export default { fetch: ... }` syntax, the `scheduled` handler is simply added alongside. If it uses `export default { async fetch() {} }` shorthand, same pattern applies.
+
+**CPU limit**: Cloudflare Workers `scheduled` handlers have a **30-second CPU time limit** (soft, may vary by plan). Process users in batches of 100, and if the batch count is large, consider using `ctx.waitUntil()` for background processing.
+
+### Progress table index check
+
+The query filters on `progress(user_id, date)`. Check if an index exists:
+- Migration `0005_add_unique_date_constraint.sql` adds `UNIQUE(date, user_id)` — this creates a unique index on `(date, user_id)`. This is sufficient for the `NOT EXISTS` subquery.
+
+### Project Structure Notes
+
+- New files:
+  - `src/push-messages.ts` — themed notification message templates
+  - `src/scheduled-handlers.ts` — cron job handler
+  - `migrations/0128_create_one_more_mile_sent.sql`
+  - `migrations/0129_add_one_more_mile_enabled.sql`
+  - `tests/api/scheduled-handlers.test.ts` — cron handler tests
+  - `tests/api/push-messages.test.ts` — message template tests (optional, can co-locate)
+- Modified files:
+  - `src/index.ts` — add `scheduled()` export, import scheduled handler
+  - `wrangler.json` — add `triggers.crons` array
+  - `src/push-handlers.ts` — extend settings endpoint for `oneMoreMileEnabled`
+  - `client/src/islands/PushPermissionIsland.tsx` — refactor into collapsible notification settings group
+  - `client/src/islands/PushPermissionIsland.test.tsx` — update tests for new UI
+  - `client/src/utils/push-client.ts` — extend `updateNotificationSettings` to support new field
+  - `public/css/profile.css` — styles for collapsible group
+  - `docs/data-models.md` — document new table + column
+  - `docs/api-reference.md` — document updated settings endpoint + cron behavior
+
+### Previous Story Intelligence (Story 11.1)
+
+- Story 11.1 establishes the push infrastructure: `push_subscriptions` table, VAPID keys, `push-handlers.ts`, `push-utils.ts`, `PushPermissionIsland`, Service Worker push/notificationclick handlers.
+- `sendPushToUser(db, userId, payload, env)` from `push-utils.ts` handles: querying all active subscriptions, checking `notifications_enabled`, sending encrypted payloads, cleaning up 410s. **Reuse this directly** — do not duplicate.
+- `cleanupExpiredSubscription(db, endpoint)` from `push-utils.ts` — reuse for 410 cleanup.
+- `PushPayload` interface from `push-utils.ts`: `{ title: string; body: string; url?: string; icon?: string }`.
+- The profile page already has a `<div data-island="PushPermissionIsland">` mount point.
+- The island reads `sessionToken` from `appStore` signals.
+- Test pattern uses `TEST_MOCK_TOKEN_<username>` for auth in tests.
+
+### CRITICAL: Do NOT
+
+- Do NOT create a separate "notification preferences" table — use columns on the `users` table (consistent with `show_future_goals_unlocked`, `default_view_map` pattern).
+- Do NOT make this notification daily — it should only fire ONCE per goal per user, and only when ALL 6 criteria are met.
+- Do NOT send to users who have completed the entire journey.
+- Do NOT hardcode cron time — use `wrangler.json` config so it can be adjusted without code changes.
+- Do NOT send notification if the user has logged ANY walk in the past 3 days (even a 0-distance entry is activity).
+- Do NOT use the `web-push` npm library — it requires Node.js crypto. Use `sendPushToUser` from `push-utils.ts` which is built for Cloudflare Workers (Web Crypto API).
+
+### References
+
+- Cron handler pattern: [Source: docs/architecture.md] — new pattern, Cloudflare Workers `scheduled()` export
+- Cron wrangler config: `"triggers": { "crons": ["0 9 * * *"] }` in `wrangler.json` — [Source: Cloudflare docs: Scheduled Handler]
+- Push utility: [Source: src/push-utils.ts (from Story 11.1)] — `sendPushToUser`, `cleanupExpiredSubscription`, `PushPayload`
+- Push handlers: [Source: src/push-handlers.ts (from Story 11.1)] — `handlePushSettings`, `handlePushStatus`
+- Goals schema: [Source: migrations/0003_init_goals.sql] — `goals.distance` is absolute position on route
+- Total distance calc: [Source: src/goals-handlers.ts#calculateTotalDistance] — sums `progress.distance`
+- Progress unique constraint: [Source: migrations/0005_add_unique_date_constraint.sql] — `UNIQUE(date, user_id)` creates index
+- Dynamic preference updates: [Source: src/auth-handlers.ts#handleUpdatePreferences] — pattern for building dynamic UPDATE SET clause
+- Island registration: [Source: client/src/index.tsx] — auto-hydration map
+- App store signals: [Source: client/src/stores/appStore.ts] — `sessionToken`, `userId`
+- Test auth pattern: [Source: tests/api/*.test.ts] — `TEST_MOCK_TOKEN_<username>`
+- Local cron testing: `npx wrangler dev --test-scheduled`, then `curl http://localhost:8787/__scheduled?cron=0+9+*+*+*`
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Opus 4.6 (GitHub Copilot)
+
+### Completion Notes List
+
+- Story created: 2026-04-10
+- User explicitly requested: <2 km threshold, 3-day inactivity window, once-per-goal dedup, themed message variety, completed-journey exclusion, separate toggle with collapsible settings group
+- Key dependency: Story 11.1 (Web Push Infrastructure) must be implemented first — this story uses `sendPushToUser`, `push_subscriptions` table, `PushPermissionIsland`, `push-handlers.ts`
+- Key new pattern: `scheduled()` handler — first cron trigger in the codebase
+- Migration numbers 0128–0129 follow Story 11.1's 0126–0127
+- The "3 days" inactivity check uses `date('now', '-3 days')` which in SQLite returns the date 3 days ago — the `>=` comparison catches any activity in the past 3 days
+
+### File List
+
+<!-- To be filled by dev agent -->

--- a/_bmad-output/implementation-artifacts/11-3-gandalfs-absence-arc-narrative-re-engagement.md
+++ b/_bmad-output/implementation-artifacts/11-3-gandalfs-absence-arc-narrative-re-engagement.md
@@ -1,0 +1,475 @@
+# Story 11.3: Gandalf's Absence Arc — Narrative Re-engagement
+
+Status: ready-for-dev
+
+## Story
+
+As an inactive user who has not logged a walk in 6 or more days,
+I want to receive a sequence of Tolkien-themed narrative push notifications that escalate from gentle encouragement to dramatic urgency,
+so that I'm drawn back to the app in a way that feels immersive and story-driven rather than nagging.
+
+## Context & Design Intent
+
+This is a **tiered narrative re-engagement sequence** — NOT a daily spam blast. Notifications follow a storytelling arc that escalates with increasing inactivity duration. Each tier fires **exactly once** per inactivity period. When the user logs a walk, the tier counter resets so the arc can restart if they go inactive again later.
+
+Key design principles:
+- **Narrative immersion**: Each tier is a story beat, not a generic "come back" message.
+- **Respectful frequency**: At most 4 notifications across an entire inactivity period (days 6, 10, 15, 25+), not daily.
+- **Opt-out respect**: Controlled by a new "Inactivity Notifications" toggle within the notification settings group.
+- **Deeplink to `/`**: Clicking the notification opens `/` so the user's `default_view_map` preference determines the landing page (journey page or map).
+- **Exclude finished users**: Users who have completed the entire journey (no remaining goals) receive no re-engagement notifications.
+- **Exclude dormant accounts**: Users who have **never** logged a single walk are excluded (they never started the journey).
+
+## Acceptance Criteria
+
+1. **Given** a user has not logged a walk in 6+ consecutive days (no entry in `progress` with `date >= date('now', '-6 days')`),
+   **And** they have at least one active push subscription,
+   **And** they have `notifications_enabled = 1` (global toggle),
+   **And** they have `inactivity_nudge_enabled = 1` (feature toggle),
+   **And** they have logged at least one walk ever (`EXISTS progress row`),
+   **And** they have not completed the full journey (a goal exists with `distance > totalDistance`),
+   **When** the daily scheduled cron job runs,
+   **Then** the system determines the correct tier based on days since last walk:
+     - Days 6–9 → Tier 1 (Gentle)
+     - Days 10–14 → Tier 2 (Concerned)
+     - Days 15–24 → Tier 3 (Urgent)
+     - Days 25+ → Tier 4 (Dramatic Final)
+   **And** if the user's `reengage_tier_sent` is below the current tier, a push notification is sent for that tier,
+   **And** `reengage_tier_sent` is updated to the sent tier value,
+   **And** the notification payload includes a randomly selected message variant for that tier with the user's next goal name interpolated,
+   **And** the notification's click-through URL is `/`.
+
+2. **Given** a user is inactive for 10 days and has already received the Tier 1 (day 6) notification,
+   **When** the cron job runs on day 10,
+   **Then** a Tier 2 notification is sent **and** `reengage_tier_sent` is updated to 2.
+
+3. **Given** a user has reached Tier 4 (`reengage_tier_sent = 4`),
+   **When** the cron job runs and the user is still inactive,
+   **Then** no further notifications are sent (Tier 4 is the final message).
+
+4. **Given** a user has `reengage_tier_sent = 3` and logs a new walk,
+   **When** the walk is saved via `POST /api/calendar-progress`,
+   **Then** `reengage_tier_sent` is reset to 0,
+   **And** the next time they go inactive for 6+ days, the arc restarts from Tier 1.
+
+5. **Given** a user has never logged any walks (no rows in `progress` for their `user_id`),
+   **When** the cron job runs,
+   **Then** no re-engagement notification is sent (they're a dormant account, not a lapsed walker).
+
+6. **Given** a user has completed the entire journey (their total distance ≥ the maximum goal distance),
+   **When** the cron job runs,
+   **Then** no re-engagement notification is sent.
+
+7. **Given** an authenticated user views the notification settings on their profile,
+   **When** the global notifications toggle is ON,
+   **Then** the expanded settings group shows an "Inactivity Notifications" toggle with description: "Receive themed reminders if you haven't walked in a while",
+   **And** the toggle defaults to ON for new users.
+
+8. **Given** a user toggles the "Inactivity Notifications" setting,
+   **When** `PUT /api/push/settings` is called with `{ inactivityNudgeEnabled: boolean }`,
+   **Then** `users.inactivity_nudge_enabled` is updated and the response confirms success.
+
+9. **Given** the cron job sends a notification and the push service returns 404 or 410 (Gone),
+   **Then** the expired subscription is cleaned up (deleted from `push_subscriptions`),
+   **And** nothing else changes — the `reengage_tier_sent` is still updated so the user isn't re-targeted at this tier if they re-subscribe.
+
+10. **Given** there are multiple themed message variants per tier,
+    **When** a notification is sent,
+    **Then** the selected variant includes a `title` and `body` that reference the user's next goal name,
+    **And** the variant is randomly chosen from the pool for that tier.
+
+11. **Given** the `scheduled()` handler already runs daily (from Story 11.2),
+    **When** the re-engagement check runs,
+    **Then** it processes after the "One More Mile" notifications in the same cron invocation,
+    **And** users are processed in batches (page size: 100) to stay within D1 row limits and Worker CPU time.
+
+12. **Given** a user receives a Gandalf's Absence Arc push notification,
+    **When** the user clicks/taps the notification,
+    **Then** the app opens to `/` (which routes to the user's preferred default view — journey or map),
+    **And** if a browser tab is already open, it focuses that existing window instead of opening a new one,
+    **And** the notification is dismissed on click.
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Database migration — `reengage_tier_sent` column on users (AC: #1, #3, #4)
+  - [ ] 1.1: Create `migrations/0130_add_reengage_tier_sent.sql`: `ALTER TABLE users ADD COLUMN reengage_tier_sent INTEGER NOT NULL DEFAULT 0;`
+  - [ ] 1.2: Update `docs/data-models.md` with new column description
+
+- [ ] Task 2: Database migration — `inactivity_nudge_enabled` user preference (AC: #7, #8)
+  - [ ] 2.1: Create `migrations/0131_add_inactivity_nudge_enabled.sql`: `ALTER TABLE users ADD COLUMN inactivity_nudge_enabled INTEGER NOT NULL DEFAULT 1;`
+  - [ ] 2.2: Update `docs/data-models.md` with new column description
+
+- [ ] Task 3: Themed message variants — add to `src/push-messages.ts` (AC: #10)
+  - [ ] 3.1: Export a `REENGAGE_MESSAGES` map keyed by tier (1–4), each tier containing an array of `{ title: string; bodyTemplate: string }` variants
+  - [ ] 3.2: Implement `getReengageMessage(tier: number, goalTitle: string)` that randomly selects a variant for the given tier and interpolates `{goalTitle}`
+  - [ ] 3.3: Include at least 4 variants per tier (16+ total messages)
+
+- [ ] Task 4: Re-engagement cron handler — add to `src/scheduled-handlers.ts` (AC: #1, #2, #3, #5, #6, #9, #11)
+  - [ ] 4.1: Add `handleReengagementCron(db: DbClient, env: Env)` function to `src/scheduled-handlers.ts`
+  - [ ] 4.2: Implement the eligible-user query: find users with `notifications_enabled = 1`, `inactivity_nudge_enabled = 1`, at least one progress row, has active push subscription, NOT completed journey, last walk date ≥ 6 days ago, and `reengage_tier_sent` < current applicable tier
+  - [ ] 4.3: Process eligible users in batches (100 per query page)
+  - [ ] 4.4: For each eligible user: determine correct tier from days-since-last-walk, select random message for that tier, call `sendPushToUser()` from `src/push-utils.ts` with URL `/`, update `reengage_tier_sent`
+  - [ ] 4.5: Handle `sendPushToUser` failures gracefully — log errors, continue processing remaining users
+  - [ ] 4.6: Clean up expired subscriptions on 404/410 (reuse `cleanupExpiredSubscription` from `push-utils.ts`)
+
+- [ ] Task 5: Wire re-engagement handler in `src/index.ts` scheduled export (AC: #11)
+  - [ ] 5.1: Add `handleReengagementCron(db, env)` call inside the existing `scheduled()` handler, after `handleOneMoreMileCron`
+  - [ ] 5.2: Wrap in try/catch so a failure in re-engagement doesn't block or affect the One More Mile processing
+
+- [ ] Task 6: Reset `reengage_tier_sent` on walk log — `src/progress-handlers.ts` (AC: #4)
+  - [ ] 6.1: In `handleProgressPost`, after successful INSERT, add: `UPDATE users SET reengage_tier_sent = 0 WHERE id = ? AND reengage_tier_sent > 0`
+  - [ ] 6.2: The reset must NOT run on PUT (edit) or DELETE — only on new walk creation
+
+- [ ] Task 7: Update push settings API — `src/push-handlers.ts` (AC: #8)
+  - [ ] 7.1: Extend `handlePushSettings` (from Stories 11.1/11.2) to accept `inactivityNudgeEnabled` in addition to existing fields
+  - [ ] 7.2: Update `PUT /api/push/settings` body validation to handle the new field (any combination of fields can be present)
+  - [ ] 7.3: Extend `GET /api/push/status` response to include `inactivityNudgeEnabled: boolean`
+
+- [ ] Task 8: Add "Inactivity Notifications" toggle to NotificationSettings UI (AC: #7)
+  - [ ] 8.1: In the `PushPermissionIsland` notification settings group (refactored in Story 11.2), add a new "Inactivity Notifications" toggle below the "One More Mile" toggle
+  - [ ] 8.2: Toggle label: "Inactivity Notifications" with description: "Receive themed reminders if you haven't walked in a while"
+  - [ ] 8.3: Wire the toggle to `PUT /api/push/settings` with `{ inactivityNudgeEnabled }` 
+  - [ ] 8.4: Load initial state for `inactivityNudgeEnabled` from `GET /api/push/status`
+
+- [ ] Task 9: Tests (AC: all)
+  - [ ] 9.1: Backend tests in `tests/api/scheduled-handlers.test.ts` (extend existing file from Story 11.2):
+    - Tier 1 notification sent at 6 days inactive
+    - Tier 2 notification sent at 10 days (with reengage_tier_sent=1)
+    - Tier 3 notification sent at 15 days (with reengage_tier_sent=2)
+    - Tier 4 notification sent at 25 days (with reengage_tier_sent=3)
+    - No notification at day 5 (below threshold)
+    - No notification when reengage_tier_sent = 4 (arc complete)
+    - No notification for user with no progress rows (dormant)
+    - No notification for user who completed the journey
+    - No notification when inactivity_nudge_enabled = 0
+    - No notification when notifications_enabled = 0
+    - reengage_tier_sent updated correctly after send
+    - Batch processing works correctly
+    - Expired subscription cleanup on 410
+  - [ ] 9.2: Backend test in `tests/api/progress-handlers.test.ts`:
+    - reengage_tier_sent resets to 0 on new walk POST
+    - reengage_tier_sent NOT reset on walk PUT or DELETE
+  - [ ] 9.3: Backend tests for updated push settings in `tests/api/push-handlers.test.ts`:
+    - `PUT /api/push/settings` with `inactivityNudgeEnabled` updates column
+    - `GET /api/push/status` returns `inactivityNudgeEnabled` field
+  - [ ] 9.4: Unit tests for message variants in `tests/api/push-messages.test.ts` (extend existing file from Story 11.2):
+    - All 4 tiers have at least 4 message variants
+    - `getReengageMessage()` interpolates goal title correctly
+    - Invalid tier returns a safe fallback or throws
+  - [ ] 9.5: Client tests in `client/src/islands/PushPermissionIsland.test.tsx` (extend from Story 11.2):
+    - "Inactivity Notifications" toggle visible in expanded notification settings
+    - Toggle calls API with correct payload
+    - Toggle reflects initial state from API
+
+## Dev Notes
+
+### Architecture & Patterns
+
+- **Handler pattern**: Follow `src/stats-handlers.ts` / `src/friends-handlers.ts`. Each handler receives `(request, db, body?, allowTestAuth?)` and returns a `Response`.
+- **DB access**: Use `db.read` for SELECT, `db.write` for INSERT/UPDATE/DELETE via `DbClient` from `src/db.ts`.
+- **Response format**: Use `createSuccessResponse(data)` and `createErrorResponse(message, statusCode)` from `src/validators.ts`.
+- **Auth validation**: `validateSession(request, db, allowTestAuth)` — returns `{ valid: true, userId }` or `{ valid: false, error: Response }`.
+
+### Tier Thresholds and Day Ranges
+
+```typescript
+const REENGAGE_TIERS = [
+  { tier: 1, minDays: 6,  maxDays: 9,  label: 'gentle' },
+  { tier: 2, minDays: 10, maxDays: 14, label: 'concerned' },
+  { tier: 3, minDays: 15, maxDays: 24, label: 'urgent' },
+  { tier: 4, minDays: 25, maxDays: Infinity, label: 'dramatic_final' },
+] as const;
+```
+
+The system calculates days since last walk, looks up which tier that falls into, and compares against `reengage_tier_sent`. If the current tier > sent tier, a notification fires.
+
+### Eligible User Query Strategy
+
+The query joins users, their latest walk date, their total distance, their next goal, and push subscription existence. It filters for all 6 eligibility criteria in one efficient CTE query:
+
+```sql
+WITH user_last_walk AS (
+  SELECT 
+    u.id AS user_id,
+    MAX(p.date) AS last_walk_date,
+    CAST(julianday('now') - julianday(MAX(p.date)) AS INTEGER) AS days_inactive,
+    u.reengage_tier_sent
+  FROM users u
+  INNER JOIN progress p ON p.user_id = u.id
+  WHERE u.notifications_enabled = 1
+    AND u.inactivity_nudge_enabled = 1
+  GROUP BY u.id
+  HAVING days_inactive >= 6
+),
+user_distances AS (
+  SELECT 
+    ulw.user_id,
+    ulw.last_walk_date,
+    ulw.days_inactive,
+    ulw.reengage_tier_sent,
+    COALESCE(SUM(p.distance), 0) AS total_distance
+  FROM user_last_walk ulw
+  INNER JOIN progress p ON p.user_id = ulw.user_id
+  GROUP BY ulw.user_id
+)
+SELECT 
+  ud.user_id,
+  ud.days_inactive,
+  ud.reengage_tier_sent,
+  ud.total_distance,
+  g.title AS next_goal_title
+FROM user_distances ud
+INNER JOIN goals g ON g.distance > ud.total_distance
+WHERE EXISTS (
+  SELECT 1 FROM push_subscriptions ps WHERE ps.user_id = ud.user_id
+)
+GROUP BY ud.user_id
+HAVING g.distance = MIN(g.distance)
+LIMIT 100 OFFSET ?;
+```
+
+**Key notes:**
+- `INNER JOIN progress` in `user_last_walk` ensures users with zero walks are excluded (dormant account exclusion).
+- `INNER JOIN goals g ON g.distance > ud.total_distance` ensures users who completed the journey are excluded (no goal beyond their distance).
+- `julianday('now') - julianday(MAX(p.date))` computes days since last walk.
+- Batch with LIMIT/OFFSET like the One More Mile query pattern.
+
+### Tier Calculation in TypeScript
+
+```typescript
+function getReengageTier(daysInactive: number): number {
+  if (daysInactive >= 25) return 4;
+  if (daysInactive >= 15) return 3;
+  if (daysInactive >= 10) return 2;
+  if (daysInactive >= 6) return 1;
+  return 0; // not eligible
+}
+```
+
+For each eligible user, call `getReengageTier(daysInactive)`. If it's greater than `reengage_tier_sent`, send a notification for that tier and update.
+
+### Themed Message Variants
+
+Four tiers with at least 4 messages each. All messages include a `{goalTitle}` placeholder for the user's next goal. The notification `url` is always `/`.
+
+**Tier 1 — Gentle (Day 6–9):**
+```typescript
+[
+  { title: "Gandalf Notices Your Absence", bodyTemplate: "\"Even the smallest step counts,\" he says. {goalTitle} still waits for you ahead." },
+  { title: "The Road Misses You", bodyTemplate: "Six days without a step — the path to {goalTitle} grows no shorter on its own." },
+  { title: "A Gentle Nudge from the Shire", bodyTemplate: "Sam's been keeping your pack ready. {goalTitle} is still out there, waiting." },
+  { title: "Your Journey Pauses", bodyTemplate: "The road to {goalTitle} is patient, but Gandalf is watching the horizon for you." },
+]
+```
+
+**Tier 2 — Concerned (Day 10–14):**
+```typescript
+[
+  { title: "The Fellowship Grows Worried", bodyTemplate: "Sam keeps glancing back down the road… {goalTitle} feels further each day." },
+  { title: "Shadows Lengthen", bodyTemplate: "Ten days off the path. The road to {goalTitle} grows darker without your footsteps." },
+  { title: "Aragorn Scouts Ahead Alone", bodyTemplate: "Without you, the company is incomplete. {goalTitle} needs every member of the fellowship." },
+  { title: "Whispers at the Council", bodyTemplate: "\"Where is our walker?\" they ask. The road to {goalTitle} awaits your return." },
+]
+```
+
+**Tier 3 — Urgent (Day 15–24):**
+```typescript
+[
+  { title: "Darkness Spreads", bodyTemplate: "Without you, the journey to {goalTitle} may be lost. Return, friend!" },
+  { title: "The Enemy Does Not Rest", bodyTemplate: "Fifteen days have passed. Sauron's reach grows while {goalTitle} remains unconquered." },
+  { title: "Gandalf's Urgent Summons", bodyTemplate: "\"To delay is to risk all.\" The path to {goalTitle} cannot wait much longer." },
+  { title: "The Beacons Are Lit!", bodyTemplate: "Middle-earth calls for aid! The road to {goalTitle} needs you now more than ever." },
+]
+```
+
+**Tier 4 — Dramatic Final (Day 25+):**
+```typescript
+[
+  { title: "A Moth Brings a Message", bodyTemplate: "A moth finds you with a message from Gandalf: \"It is not too late.\" {goalTitle} still stands." },
+  { title: "One Last Hope", bodyTemplate: "Even in the darkest hour, a single step towards {goalTitle} can change everything." },
+  { title: "The Grey Pilgrim's Final Plea", bodyTemplate: "\"I will not say: do not weep; for not all tears are an evil.\" But the road to {goalTitle} still remains." },
+  { title: "All Is Not Lost", bodyTemplate: "Twenty-five days in shadow, yet {goalTitle} endures. One walk. That is all that is asked of you." },
+]
+```
+
+**Random selection**: Use `Math.floor(Math.random() * messages.length)` — no need for crypto-grade randomness. Same pattern as `getOneMoreMileMessage` from Story 11.2.
+
+**Interpolation**: Simple string replace: `.replace(/{goalTitle}/g, goalTitle)`.
+
+### Walk Log Reset — `src/progress-handlers.ts`
+
+In `handleProgressPost`, after the successful `INSERT INTO progress`, add a single UPDATE to reset the re-engagement tier:
+
+```typescript
+// Reset re-engagement tier on new walk (not on PUT/DELETE)
+await db.write.prepare(
+  'UPDATE users SET reengage_tier_sent = 0 WHERE id = ? AND reengage_tier_sent > 0'
+).bind(userId).run();
+```
+
+The `AND reengage_tier_sent > 0` guard avoids unnecessary writes for active users. This runs alongside the existing `syncPartyProgressLog()` call. If the reset fails, it should NOT block the walk from being saved — wrap in try/catch with `console.error`.
+
+### Push Settings API Extension
+
+Story 11.2 extends `PUT /api/push/settings` to accept `{ notificationsEnabled?, oneMoreMileEnabled? }`. This story adds `inactivityNudgeEnabled`:
+
+- Accept body: `{ notificationsEnabled?: boolean, oneMoreMileEnabled?: boolean, inactivityNudgeEnabled?: boolean }` — any combination.
+- Validate: if `inactivityNudgeEnabled` is present, it must be a boolean.
+- Update: follow the same dynamic UPDATE SET pattern from `handleUpdatePreferences` in `auth-handlers.ts`:
+  ```typescript
+  if (hasInactivityNudge) {
+    updates.push('inactivity_nudge_enabled = ?');
+    values.push(inactivityNudgeEnabled ? 1 : 0);
+  }
+  ```
+- Extend `GET /api/push/status` response to include `inactivityNudgeEnabled: boolean`.
+
+### Notification Settings UI — Adding the Toggle
+
+The `PushPermissionIsland` is refactored by Story 11.2 into a collapsible "Notification Settings" group. This story adds a second toggle inside that expanded group:
+
+```
+┌─ Notification Settings ──────────────────┐
+│ 🔔 Push Notifications  [━━━━●] ON       │  ← Global toggle (collapse header)
+│                                           │
+│ ┌─ Notification Types ─────────────────┐ │  ← Revealed when global is ON
+│ │ 📍 One More Mile      [━━━━●] ON    │ │  ← From Story 11.2
+│ │   Get a nudge when you're close to   │ │
+│ │   your next milestone.               │ │
+│ │                                      │ │
+│ │ 🧙 Inactivity Notifications [━━●] ON│ │  ← NEW in this story
+│ │   Receive themed reminders if you    │ │
+│ │   haven't walked in a while.         │ │
+│ └──────────────────────────────────────┘ │
+│                                           │
+│ Enabled on 2 devices                      │
+└───────────────────────────────────────────┘
+```
+
+**Implementation**: Follow the exact same toggle pattern established by the "One More Mile" toggle in Story 11.2 — same CSS classes, same API call pattern, same state loading from `GET /api/push/status`.
+
+### Scheduled Handler — Sequential Processing
+
+The `scheduled()` handler in `src/index.ts` (added by Story 11.2) runs `handleOneMoreMileCron`. This story adds re-engagement as a second, independent pass:
+
+```typescript
+async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext): Promise<void> {
+  const db = createDbClient(env.DB);
+  
+  // Run both independently — failure in one should not block the other
+  try {
+    await handleOneMoreMileCron(db, env);
+  } catch (err) {
+    console.error('One More Mile cron failed:', err);
+  }
+  
+  try {
+    await handleReengagementCron(db, env);
+  } catch (err) {
+    console.error('Re-engagement cron failed:', err);
+  }
+}
+```
+
+**CPU time**: Cloudflare Workers `scheduled()` has a 30-second CPU time limit. Both handlers share this budget. If combined processing is too large, consider splitting into separate cron schedules later. For current user volumes this is not a concern.
+
+### Migration Details
+
+- **Next migration numbers**: `0130` and `0131` (after Story 11.2's `0128` and `0129`)
+- **0130_add_reengage_tier_sent.sql**:
+  ```sql
+  ALTER TABLE users ADD COLUMN reengage_tier_sent INTEGER NOT NULL DEFAULT 0;
+  ```
+- **0131_add_inactivity_nudge_enabled.sql**:
+  ```sql
+  ALTER TABLE users ADD COLUMN inactivity_nudge_enabled INTEGER NOT NULL DEFAULT 1;
+  ```
+
+### CRITICAL: Do NOT
+
+- Do NOT send more than one re-engagement notification per day per user — the tier system inherently prevents this.
+- Do NOT send re-engagement notifications to users who have **never** walked (no progress rows). They are dormant accounts, not lapsed walkers.
+- Do NOT send to users who have completed the entire journey.
+- Do NOT send if either `notifications_enabled` or `inactivity_nudge_enabled` is 0.
+- Do NOT reset `reengage_tier_sent` on walk PUT or DELETE — only on POST (new walk creation).
+- Do NOT create a separate table for tier tracking — use a column on `users` (consistent with `one_more_mile_enabled`, `notifications_enabled` pattern).
+- Do NOT block the walk save if the tier reset fails — wrap in try/catch.
+- Do NOT use the `web-push` npm library — reuse `sendPushToUser` from `push-utils.ts` (Cloudflare Workers Web Crypto API).
+- Do NOT modify the One More Mile cron logic — this story only adds a new handler called sequentially after it.
+
+### Previous Story Intelligence (Story 11.2)
+
+From Story 11.2's design:
+- `src/scheduled-handlers.ts` will contain `handleOneMoreMileCron(db, env)` — add `handleReengagementCron(db, env)` to the same file.
+- `src/push-messages.ts` will contain `ONE_MORE_MILE_MESSAGES` — add `REENGAGE_MESSAGES` map to the same file.
+- The `scheduled()` export in `src/index.ts` will already exist — add the re-engagement call alongside.
+- `PUT /api/push/settings` will already accept multiple optional fields — extend with the new one.
+- `GET /api/push/status` will already return `oneMoreMileEnabled` — extend with `inactivityNudgeEnabled`.
+- The collapsible notification settings UI group in `PushPermissionIsland` will already exist — add the new toggle inside it.
+- Batch processing (LIMIT 100 OFFSET) and expired subscription cleanup patterns are established.
+- `sendPushToUser(db, userId, payload, env)` from `push-utils.ts` handles all encryption, delivery, and 410 cleanup.
+- `PushPayload` interface: `{ title: string; body: string; url?: string; icon?: string }`.
+- Test pattern: `TEST_MOCK_TOKEN_<username>` for auth.
+
+### Project Structure Notes
+
+- New files:
+  - `migrations/0130_add_reengage_tier_sent.sql`
+  - `migrations/0131_add_inactivity_nudge_enabled.sql`
+- Modified files:
+  - `src/push-messages.ts` — add `REENGAGE_MESSAGES` and `getReengageMessage()`
+  - `src/scheduled-handlers.ts` — add `handleReengagementCron()`
+  - `src/index.ts` — add `handleReengagementCron` call in `scheduled()` handler
+  - `src/progress-handlers.ts` — reset `reengage_tier_sent` on new walk POST
+  - `src/push-handlers.ts` — extend settings endpoint for `inactivityNudgeEnabled`
+  - `client/src/islands/PushPermissionIsland.tsx` — add "Inactivity Notifications" toggle
+  - `client/src/islands/PushPermissionIsland.test.tsx` — add tests for new toggle
+  - `client/src/utils/push-client.ts` — extend `updateNotificationSettings` to support new field
+  - `docs/data-models.md` — document new columns
+  - `docs/api-reference.md` — document updated settings endpoint
+
+### References
+
+- Scheduled handler pattern: [Source: src/index.ts] — `scheduled()` export added by Story 11.2
+- Scheduled handler file: [Source: src/scheduled-handlers.ts (from Story 11.2)] — `handleOneMoreMileCron`
+- Message template pattern: [Source: src/push-messages.ts (from Story 11.2)] — `ONE_MORE_MILE_MESSAGES`, `getOneMoreMileMessage()`
+- Push utility: [Source: src/push-utils.ts (from Story 11.1)] — `sendPushToUser`, `cleanupExpiredSubscription`, `PushPayload`
+- Push handlers: [Source: src/push-handlers.ts (from Story 11.1/11.2)] — `handlePushSettings`, `handlePushStatus`
+- Walk logging: [Source: src/progress-handlers.ts] — `handleProgressPost` for tier reset hook, `syncPartyProgressLog()` pattern for graceful degradation
+- Dynamic preference updates: [Source: src/auth-handlers.ts#handleUpdatePreferences] — pattern for building dynamic UPDATE SET clause
+- Notification settings UI: [Source: client/src/islands/PushPermissionIsland.tsx (from Story 11.2)] — collapsible group, toggle pattern
+- Goals schema: [Source: migrations/0003_init_goals.sql] — `goals.distance` is absolute position on route
+- Total distance calc: [Source: src/goals-handlers.ts] — sums `progress.distance`
+- Progress unique constraint: [Source: migrations/0005_add_unique_date_constraint.sql] — `UNIQUE(date, user_id)` index
+- Profile island: [Source: client/src/islands/ProfileIsland.tsx] — toggle UI patterns with `toggle-group`, `toggle-switch`, `toggle-slider` CSS classes
+- Profile styles: [Source: public/css/profile.css] — existing toggle-group / toggle-switch / toggle-slider styles
+- Island registration: [Source: client/src/index.tsx] — auto-hydration map
+- Test auth pattern: [Source: tests/api/*.test.ts] — `TEST_MOCK_TOKEN_<username>`
+- Local cron testing: `npx wrangler dev --test-scheduled`, then `curl http://localhost:8787/__scheduled?cron=0+9+*+*+*`
+- Epic 11 Story 11.3 definition: [Source: _bmad-output/planning-artifacts/epics-phases-4-15.md#Story 11.3]
+- FR_ENGAGE_01, NFR_REENGAGE_01: [Source: _bmad-output/planning-artifacts/epics-phases-4-15.md#Requirements Inventory]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Opus 4.6 (GitHub Copilot)
+
+### Completion Notes List
+
+- Story created: 2026-04-10
+- Ultimate context engine analysis completed — comprehensive developer guide created
+- Key design decisions per user request:
+  - Deeplink URL is `/` (not `/journey`) so `default_view_map` preference determines landing page
+  - Users who finished the journey (no remaining goals) are excluded from notifications
+  - New "Inactivity Notifications" toggle added to the notification settings group (same pattern as "One More Mile" from Story 11.2)
+  - Titles and bodies designed for each of 4 tiers with Tolkien narrative arc (gentle → concerned → urgent → dramatic)
+- Key dependency: Stories 11.1 (push infrastructure) and 11.2 (scheduled handler, notification settings group, message template file) must be implemented first
+- Epic originally specified days [3, 7, 14, 21+] but story uses [6, 10, 15, 25] per the epic's own AC text — these are the canonical thresholds
+- `reengage_tier_sent` column on `users` table tracks arc progression (0 = no notifications sent, 1–4 = tier reached)
+- Tier resets to 0 on new walk POST only (not PUT/DELETE) — this is the "activity resumes" signal
+- Migration numbers 0130–0131 follow Story 11.2's 0128–0129
+
+### File List
+
+<!-- To be filled by dev agent -->

--- a/_bmad-output/implementation-artifacts/11-3-gandalfs-absence-arc-narrative-re-engagement.md
+++ b/_bmad-output/implementation-artifacts/11-3-gandalfs-absence-arc-narrative-re-engagement.md
@@ -219,18 +219,18 @@ SELECT
   ud.total_distance,
   g.title AS next_goal_title
 FROM user_distances ud
-INNER JOIN goals g ON g.distance > ud.total_distance
+INNER JOIN goals g ON g.distance = (
+  SELECT MIN(g2.distance) FROM goals g2 WHERE g2.distance > ud.total_distance
+)
 WHERE EXISTS (
   SELECT 1 FROM push_subscriptions ps WHERE ps.user_id = ud.user_id
 )
-GROUP BY ud.user_id
-HAVING g.distance = MIN(g.distance)
 LIMIT 100 OFFSET ?;
 ```
 
 **Key notes:**
 - `INNER JOIN progress` in `user_last_walk` ensures users with zero walks are excluded (dormant account exclusion).
-- `INNER JOIN goals g ON g.distance > ud.total_distance` ensures users who completed the journey are excluded (no goal beyond their distance).
+- The correlated subquery `SELECT MIN(g2.distance) ... WHERE g2.distance > ud.total_distance` returns NULL when no goal lies ahead, so the `INNER JOIN` silently drops users who completed the journey.
 - `julianday('now') - julianday(MAX(p.date))` computes days since last walk.
 - Batch with LIMIT/OFFSET like the One More Mile query pattern.
 

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -171,7 +171,7 @@ development_status:
   11-1-web-push-api-infrastructure: ready-for-dev
   11-2-one-more-mile-push-notification: ready-for-dev
   11-3-gandalfs-absence-arc-narrative-re-engagement: ready-for-dev
-  11-4-the-dead-marshes-inactive-friends-on-map: backlog
+  11-4-the-dead-marshes-inactive-friends-on-map: cancelled
   epic-11-retrospective: optional
 
   # ============================================

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-03-17
-# last_updated: 2026-04-08
+# last_updated: 2026-04-10
 # project: walk-to-mordor
 # project_key: NOKEY
 # tracking_system: file-system
@@ -38,7 +38,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-03-17
-last_updated: 2026-04-08
+last_updated: 2026-04-10
 project: walk-to-mordor
 project_key: NOKEY
 tracking_system: file-system
@@ -167,10 +167,10 @@ development_status:
   # ============================================
   # EPIC 11: Push Notifications & Re-engagement (Phase 8)
   # ============================================
-  epic-11: backlog
-  11-1-web-push-api-infrastructure: backlog
-  11-2-one-more-mile-daily-push-notification: backlog
-  11-3-gandalfs-absence-arc-narrative-re-engagement: backlog
+  epic-11: in-progress
+  11-1-web-push-api-infrastructure: ready-for-dev
+  11-2-one-more-mile-push-notification: ready-for-dev
+  11-3-gandalfs-absence-arc-narrative-re-engagement: ready-for-dev
   11-4-the-dead-marshes-inactive-friends-on-map: backlog
   epic-11-retrospective: optional
 

--- a/_bmad-output/planning-artifacts/epics-phases-4-15.md
+++ b/_bmad-output/planning-artifacts/epics-phases-4-15.md
@@ -826,7 +826,7 @@ So that I'm drawn back to the app in a way that feels immersive rather than nagg
 **Technical Notes:**
 - Add `last_walk_date` (computed or cached) and `reengage_tier_sent` INTEGER (0–4) to track state
 - The scheduled Worker already runs daily (Story 11.2) — add re-engagement as a second pass in the same handler
-- Query: `SELECT user_id FROM users WHERE last_walk_date < date('now', '-3 days') AND reengage_tier_sent < 4`
+- Query: `SELECT user_id FROM users WHERE last_walk_date < date('now', '-6 days') AND reengage_tier_sent < 4`
 - Tier thresholds: `[6, 10, 15, 25]` days since last walk → tier `[1, 2, 3, 4]`
 - Reset `reengage_tier_sent = 0` when a new walk is logged (add to walk logging handler)
 

--- a/_bmad-output/planning-artifacts/epics-phases-4-15.md
+++ b/_bmad-output/planning-artifacts/epics-phases-4-15.md
@@ -172,7 +172,7 @@ Each epic is designed to be independently deliverable (with noted exceptions for
 
 **Goal:** Themed, respectful nudges bring users back — daily distance reminders, narrative re-engagement arcs after inactivity, and social encouragement for inactive friends on the map.
 
-**FRs Covered:** FR_PUSH_01, FR_PUSH_02, FR_ENGAGE_01 ~~FR_ENGAGE_02~~ (cancelled)
+**FRs Covered:** FR_PUSH_01, FR_PUSH_02, FR_ENGAGE_01, ~~FR_ENGAGE_02~~ (cancelled)
 
 **NFRs:** NFR_PUSH_01, NFR_REENGAGE_01
 

--- a/_bmad-output/planning-artifacts/epics-phases-4-15.md
+++ b/_bmad-output/planning-artifacts/epics-phases-4-15.md
@@ -1555,7 +1555,7 @@ So that milestones become shared storytelling moments in our journey.
 | Epic 8: Architecture & Performance | 5 | 3 | P1 | None |
 | Epic 9: Journey UX Enhancement | 6 | 2 | P1 | None |
 | Epic 10: Stats, Insights & Offline | 7 | 4 | P1–P2 | Epic 8 (Story 10.4 depends on 8.3) |
-| Epic 11: Push Notifications | 8 | 3 (1 cancelled) | P0–P1 | None (internal: 11.2–11.3 depend on 11.1) |
+| Epic 11: Push Notifications | 8 | 3 (1 cancelled) | P0–P2 | None (internal: 11.2–11.3 depend on 11.1) |
 | Epic 12: Events & Challenges | 9 | 3 | P0–P1 | None (internal: 12.2–12.3 depend on 12.1) |
 | Epic 13: AI Narration | 10 | 2 | P1 | None (internal: 13.2 depends on 13.1) |
 | Epic 14: Distance Lending | 11 | 2 | P1 | None (internal: 14.2 depends on 14.1) |

--- a/_bmad-output/planning-artifacts/epics-phases-4-15.md
+++ b/_bmad-output/planning-artifacts/epics-phases-4-15.md
@@ -106,7 +106,7 @@ Each epic is designed to be independently deliverable (with noted exceptions for
 | FR_PUSH_01 | Epic 11 | Web Push infrastructure |
 | FR_PUSH_02 | Epic 11 | "One More Mile" daily notification |
 | FR_ENGAGE_01 | Epic 11 | Gandalf's Absence Arc |
-| FR_ENGAGE_02 | Epic 11 | The Dead Marshes |
+| ~~FR_ENGAGE_02~~ | ~~Epic 11~~ | ~~The Dead Marshes~~ — CANCELLED |
 | FR_EVENT_01 | Epic 12 | Event engine schema & lifecycle |
 | FR_EVENT_02 | Epic 12 | Nazgûl Pursuit personal challenges |
 | FR_EVENT_03 | Epic 12 | Community Milestones |
@@ -172,7 +172,7 @@ Each epic is designed to be independently deliverable (with noted exceptions for
 
 **Goal:** Themed, respectful nudges bring users back — daily distance reminders, narrative re-engagement arcs after inactivity, and social encouragement for inactive friends on the map.
 
-**FRs Covered:** FR_PUSH_01, FR_PUSH_02, FR_ENGAGE_01, FR_ENGAGE_02
+**FRs Covered:** FR_PUSH_01, FR_PUSH_02, FR_ENGAGE_01 ~~FR_ENGAGE_02~~ (cancelled)
 
 **NFRs:** NFR_PUSH_01, NFR_REENGAGE_01
 
@@ -801,7 +801,7 @@ So that I'm reminded to walk and motivated by seeing the finish line.
 
 **Priority:** P2
 
-**Description:** After 3+ days of inactivity, send a sequence of Tolkien-themed push notifications that follow a narrative arc — from gentle encouragement to dramatic urgency — to bring the user back.
+**Description:** After 6+ days of inactivity, send a sequence of Tolkien-themed push notifications that follow a narrative arc — from gentle encouragement to dramatic urgency — to bring the user back.
 
 As an inactive user,
 I want to receive themed narrative nudges that feel like part of the story,
@@ -809,13 +809,13 @@ So that I'm drawn back to the app in a way that feels immersive rather than nagg
 
 **Acceptance Criteria:**
 
-**Given** a user has not logged a walk in 3 or more consecutive days and has an active push subscription
+**Given** a user has not logged a walk in 6 or more consecutive days and has an active push subscription
 **When** the daily scheduled Worker runs
 **Then** the user receives a push notification from a tiered narrative sequence:
-- **Day 3**: Gentle ("Gandalf notices you've paused. 'Even the smallest step counts,' he says.")
-- **Day 5**: Concerned ("The Fellowship grows worried. Sam keeps glancing back down the road…")
-- **Day 7**: Urgent ("Darkness spreads. Without you, the journey may be lost. Return, friend!")
-- **Day 14+**: Dramatic final ("A moth finds you with a message from Gandalf: 'It is not too late.'")
+- **Day 6**: Gentle ("Gandalf notices you've paused. 'Even the smallest step counts,' he says.")
+- **Day 10**: Concerned ("The Fellowship grows worried. Sam keeps glancing back down the road…")
+- **Day 15**: Urgent ("Darkness spreads. Without you, the journey may be lost. Return, friend!")
+- **Day 25+**: Dramatic final ("A moth finds you with a message from Gandalf: 'It is not too late.'")
 **And** each tier is sent only once (tracked via a `last_reengage_tier` column or similar on users/push_subscriptions)
 **And** the tier resets when the user logs a new walk (activity resumes)
 **And** the notification deep-links to the journey page
@@ -827,7 +827,7 @@ So that I'm drawn back to the app in a way that feels immersive rather than nagg
 - Add `last_walk_date` (computed or cached) and `reengage_tier_sent` INTEGER (0–4) to track state
 - The scheduled Worker already runs daily (Story 11.2) — add re-engagement as a second pass in the same handler
 - Query: `SELECT user_id FROM users WHERE last_walk_date < date('now', '-3 days') AND reengage_tier_sent < 4`
-- Tier thresholds: `[3, 5, 7, 14]` days since last walk → tier `[1, 2, 3, 4]`
+- Tier thresholds: `[6, 10, 15, 25]` days since last walk → tier `[1, 2, 3, 4]`
 - Reset `reengage_tier_sent = 0` when a new walk is logged (add to walk logging handler)
 
 **FRs:** FR_ENGAGE_01 | **NFRs:** NFR_REENGAGE_01
@@ -836,7 +836,9 @@ So that I'm drawn back to the app in a way that feels immersive rather than nagg
 
 ---
 
-#### Story 11.4: The Dead Marshes — Inactive Friends on Map
+#### ~~Story 11.4: The Dead Marshes — Inactive Friends on Map~~ — CANCELLED
+
+**Status:** Cancelled — redundant with existing notification patterns; may revisit later.
 
 **Priority:** P2
 
@@ -1553,7 +1555,7 @@ So that milestones become shared storytelling moments in our journey.
 | Epic 8: Architecture & Performance | 5 | 3 | P1 | None |
 | Epic 9: Journey UX Enhancement | 6 | 2 | P1 | None |
 | Epic 10: Stats, Insights & Offline | 7 | 4 | P1–P2 | Epic 8 (Story 10.4 depends on 8.3) |
-| Epic 11: Push Notifications | 8 | 4 | P0–P2 | None (internal: 11.2–11.4 depend on 11.1) |
+| Epic 11: Push Notifications | 8 | 3 (1 cancelled) | P0–P1 | None (internal: 11.2–11.3 depend on 11.1) |
 | Epic 12: Events & Challenges | 9 | 3 | P0–P1 | None (internal: 12.2–12.3 depend on 12.1) |
 | Epic 13: AI Narration | 10 | 2 | P1 | None (internal: 13.2 depends on 13.1) |
 | Epic 14: Distance Lending | 11 | 2 | P1 | None (internal: 14.2 depends on 14.1) |
@@ -1561,7 +1563,7 @@ So that milestones become shared storytelling moments in our journey.
 | Epic 16: Campfire Stories & Lore | 13 | 3 | P0–P2 | None (internal: 16.2–16.3 depend on 16.1) |
 | Epic 17: Field Guide | 14 | 2 | P1 | None (internal: 17.2 depends on 17.1) |
 | Epic 18: Milestone Journals | 15 | 2 | P1 | None (internal: 18.2 depends on 18.1) |
-| **Total** | | **32** | | |
+| **Total** | | **31** (1 cancelled) | | |
 
 ### Dependency Map
 


### PR DESCRIPTION
- Added a new story (11.3) for a tiered narrative re-engagement sequence targeting inactive users.
- Users inactive for 6+ days will receive themed push notifications that escalate in urgency.
- Introduced new database columns: `reengage_tier_sent` and `inactivity_nudge_enabled` to track user engagement.
- Updated acceptance criteria to reflect new inactivity thresholds and notification logic.
- Enhanced the notification settings UI to include an "Inactivity Notifications" toggle.
- Adjusted sprint status and epics to reflect the current development progress and cancelled stories.