### PR TITLE
Add rich content management, global Field Guide, and milestone journals

### DIFF
--- a/openspec/changes/field-guide-collectible-discovery/.openspec.yaml
+++ b/openspec/changes/field-guide-collectible-discovery/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-30

--- a/openspec/changes/field-guide-collectible-discovery/design.md
+++ b/openspec/changes/field-guide-collectible-discovery/design.md
@@ -1,0 +1,131 @@
+## Context
+
+Walk to Mordor already models journey progress as raw walking distance plus storyline-specific presentation state. Milestones are currently deterministic because they are tied to ordered `storyline_goals`, while the map can already derive exact coordinates for any distance on a path through the existing `getUserPosition()` pipeline.
+
+The product shape is a global Field Guide spanning all storylines, with reusable regions such as Hollin or Fangorn appearing once in the collection even when they map to multiple storyline distance bands. Discoveries must feel exploratory rather than deterministic, preserve duplicates immutably, and place first-discovery markers on the map without being vulnerable to progress-edit farming.
+
+This is cross-cutting because it introduces new D1 models, new admin workflows, new public APIs, progress-handler side effects, new Field Guide UI, and a new Konva marker layer. It also overlaps with active OpenSpec work around progress reconciliation, immutable repeatable achievements, and route-aware presentation.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide one global Field Guide collection per user that persists across storyline switches.
+- Model reusable regions separately from storyline mappings so the same region and collectible roster can appear on multiple routes at different distances.
+- Let admins manage regions, region-to-storyline distance bands, and collectible catalog entries independently from storyline admin.
+- Trigger collectible discovery from positive walk-distance changes rather than fixed milestone unlocks.
+- Support duplicates as immutable discovery instances while revealing each collectible slot on first find.
+- Show first-discovery markers on compatible map paths.
+- Count both first discoveries and duplicates in the Field Guide drawer badge.
+- Keep the MVP limited to flora and fauna while staying compatible with future repeatable badge support.
+- Avoid historical backfill so the collection begins fresh at launch.
+- When map dev mode (`window.__MAP_DEV_LOG`) is active, render region distance bands visually on the path so admins and developers can debug mapping coverage and boundary placement.
+
+**Non-Goals:**
+- No milestone-based collectible unlocks.
+- No non-flora/fauna categories in MVP.
+- No per-duplicate map markers in MVP.
+- No social sharing, showcasing, or friend-visible collectible markers in MVP.
+- No duplicate-threshold achievement awarding in MVP.
+- No requirement that every storyline distance must belong to a mapped region in the first release.
+- No revocation of discoveries after walk edits or deletes.
+
+## Decisions
+
+### Use global reusable regions plus storyline distance-band mappings
+
+The design will model Field Guide regions as first-class reusable entities with their own slug, title, description, artwork metadata, and global sort order. A separate mapping table will link each region to one or more storylines with start and end distance bands.
+
+Rationale: the product explicitly wants one shared Hollin collection even when Hollin appears on multiple outward and return journeys. Tying regions directly to a single storyline would duplicate content and fracture the user's collection.
+
+Alternative considered: storing region labels directly on collectibles or on storyline rows. Rejected because the same region would need duplicated entries and would not support one shared Field Guide section across routes.
+
+### Keep collectible entries global to a region, not to goals or storyline mappings
+
+Collectible definitions will belong to a reusable region and carry category (`flora` or `fauna`), rarity tier, slot order, name, lore text, and illustration metadata. Storyline mappings determine where a region is encountered; they do not create storyline-specific copies of collectibles.
+
+Rationale: users should reveal the same region roster regardless of which storyline led them there. This also keeps the Field Guide page global instead of route-fragmented.
+
+Alternative considered: attaching collectibles directly to storyline-region mappings. Rejected because it would create duplicate region pages and make global collection progress incoherent.
+
+### Trigger discovery from positive walk deltas and split attempts by traversed region segments
+
+Discovery rolls will be evaluated only when a walk entry adds positive distance on `POST` or `PUT`. The system will derive the positive delta in displayed storyline distance, intersect that interval with the active storyline's mapped region bands, and allocate discovery attempts across the traversed region segments rather than only the ending region.
+
+Rationale: this matches the intended feel of finding things while traveling through the world, including long walks that cross region boundaries.
+
+Alternative considered: rolling only against the ending region. Rejected because it makes boundaries gameable and causes long walks to skip collectibles from regions the user actually traversed.
+
+### Use distance-budget attempts with tier-based odds and a long-walk rare bump
+
+The system will convert each positive walked delta into multiple discovery attempts from a distance budget. Attempts first resolve a rarity tier using shared tier odds, then select uniformly from eligible undiscovered or already-discovered collectibles in the active region pool for that tier. Walk entries above a configured long-walk threshold will receive a slight bump toward rarer tiers, but MVP will not store per-item roll weights.
+
+Rationale: this preserves the user's desired “chance scales with distance entered” behavior while keeping rarity tuning understandable and content authoring simple.
+
+Alternative considered: one large percentage roll per walk entry. Rejected because it is harder to tune across short and long walks and makes edge cases around very large manual entries more extreme.
+
+Alternative considered: item-specific roll weights. Rejected for MVP because the user explicitly wants rarity-tier-based odds instead of authoring per-item chances.
+
+### Prevent progress-edit farming with per-date discovery high-water state
+
+The system will track a per-user, per-date high-water mark for discovery processing. New walk entries process their full distance once. Updates only generate new discovery attempts for distance above that date's previously processed high-water mark. Decreases and deletes do not revoke discoveries and do not reduce the stored high-water mark.
+
+Rationale: discoveries are meant to be immutable, but the product also should not allow farming by repeatedly raising and lowering the same daily entry.
+
+Alternative considered: using the current row value only and ignoring prior processed state. Rejected because a user could repeatedly edit the same date downward and upward to farm discoveries.
+
+### Store immutable discovery instances and derive duplicates and first markers from them
+
+Each successful discovery will be stored as an append-only discovery instance containing the user, collectible, discovered-at timestamp, storyline context, path key, and displayed storyline distance at the moment of discovery. The first instance for a collectible becomes the source of truth for its map marker. Duplicate counts are derived by counting all instances for that collectible and user.
+
+Rationale: append-only discovery instances align with the desired immutable collection behavior and keep future repeatable badge integration compatible with the shared achievement direction already being established elsewhere.
+
+Alternative considered: one mutable row per user and collectible with an incrementing counter. Rejected because it loses first-discovery context and makes future occurrence-based rewards less robust.
+
+### Keep unread badge state server-backed and count duplicates
+
+Unread Field Guide state will be tracked in D1 using user-scoped state that records the latest seen discovery instance. The drawer badge will count all later discovery instances, including duplicates, until the user visits or explicitly marks the Field Guide as seen.
+
+Rationale: the collection is global and durable, so unread state should behave consistently across devices and browsers.
+
+Alternative considered: localStorage-only last-visit tracking. Rejected because it makes badge counts device-specific and out of sync with a global collection.
+
+### Show first-discovery markers only on matching map paths
+
+Map markers will render only for collectibles whose first discovery was recorded on the currently displayed map path. If the user switches to a different storyline path, markers from incompatible paths are hidden rather than projected onto the wrong route. Duplicates do not create additional markers in MVP.
+
+Rationale: first-discovery locations are path-specific because map coordinates are derived from the stored path and storyline distance at discovery time.
+
+Alternative considered: projecting every first discovery onto every mapped storyline version of the same region. Rejected because it invents locations the user never actually discovered on that route.
+
+### Keep region admin separate from storyline admin while allowing mapping crossover
+
+Regions and collectibles will be administered in a dedicated Field Guide admin surface. Storyline crossover will be handled through explicit mapping UIs or APIs that reference existing storylines, but Field Guide administration will not be embedded inside the storyline editor.
+
+Rationale: the product explicitly wants region management separate from storyline admin, while still supporting reusable distance-band mappings.
+
+Alternative considered: extending `AdminStorylinesIsland` directly. Rejected because it would mix route editing with collectible catalog management and make reusable-region authoring harder to reason about.
+
+## Risks / Trade-offs
+
+- [Route mapping ambiguity] → Overlapping region bands within the same storyline could make discovery pools ambiguous. Mitigation: disallow overlapping active mappings per storyline while permitting unmapped gaps.
+- [Progress hook contention] → This change and the active events work both need side effects in `progress-handlers.ts`. Mitigation: centralize post-write hooks and keep each concern isolated and idempotent.
+- [Large walk entries skew rarity] → Very large manual entries can distort perceived rarity. Mitigation: use distance-budget attempts with configured per-request caps and a modest rare-tier bump rather than uncapped percentage escalation.
+- [Map clutter] → A mature collection can place many first-discovery markers on one path. Mitigation: reuse existing Konva marker clustering and keep MVP to first-discovery markers only.
+- [Partial region coverage] → Unmapped storyline gaps mean users may walk without eligible discoveries in some spans. Mitigation: allow this in MVP for rollout flexibility, but make gaps visible in admin tooling.
+- [Cross-change achievement drift] → Future duplicate-threshold badges could fork from the shared achievement model. Mitigation: store immutable discovery instances in a shape compatible with later occurrence-based badge awarding instead of inventing a separate mutable counter model.
+
+## Migration Plan
+
+1. Add additive D1 migrations for reusable regions, storyline-region mappings, collectible definitions, discovery high-water state, immutable user discovery instances, and user unread state.
+2. Seed initial reusable regions, mappings, and flora/fauna catalog entries before enabling discovery logic in production.
+3. Add admin APIs and dedicated admin UI for region, mapping, and collectible management.
+4. Add public Field Guide list/detail/status endpoints plus a mark-seen endpoint for unread badge behavior.
+5. Extend progress create and update flows to evaluate discovery attempts from positive deltas, while leaving delete flows non-revoking.
+6. Add the Field Guide page, drawer badge updates, and first-discovery map markers.
+7. Update docs and add backend, client, and Playwright coverage.
+
+Rollback strategy: keep migrations additive. If the UI or route handlers need to be rolled back, the app can stop reading Field Guide tables without affecting canonical walk history. Existing discovery instances remain stored for later repair or re-enable, and no revocation is required.
+
+## Open Questions
+
+None currently blocking. Initial rarity-tier odds, long-walk threshold, and per-request attempt caps can be implementation-tuned as constants within the constraints of this design.

--- a/openspec/changes/field-guide-collectible-discovery/proposal.md
+++ b/openspec/changes/field-guide-collectible-discovery/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Walk to Mordor currently rewards progress mainly through fixed milestones. A collectible field guide becomes more motivating if it behaves like exploration: users discover flora and fauna through walking itself, keep a permanent collection across all storylines, and gain reasons to keep logging distance even between major milestones.
+
+## What Changes
+
+- Introduce a global Field Guide collection for collectible Middle-earth flora and fauna that persists across all storylines.
+- Model reusable geographic regions in D1, with separate storyline-to-region distance-band mappings so the same region and guide page can appear at different distances on different routes.
+- Add admin management for Field Guide regions, region-to-storyline mappings, and collectible catalog entries with category, rarity tier, artwork, silhouette ordering, and authored lore text.
+- Add probabilistic discovery triggered by positive walk-distance changes, using multiple attempts from a walk-distance budget, immutable discovery records, and rarity-tier odds with a slight rare-tier bump for unusually long walk entries.
+- Show the Field Guide as a dedicated user-facing page with region sections in fixed slot order, silhouettes visible from the start, discovered entries revealed in place, duplicate counts, and filters for flora and fauna.
+- Add first-discovery map markers so users can see where each collectible was first found on the active storyline path.
+- Add lightweight “new since last visit” tracking for the Field Guide drawer badge, counting both first discoveries and duplicates.
+- Explicitly defer duplicate-threshold achievements, sharing/showcasing, and non-flora/fauna categories from MVP while keeping the design compatible with the shared repeatable-achievement model already being introduced elsewhere.
+- Do not backfill discoveries for existing users; collection starts fresh when the feature launches.
+
+## Capabilities
+
+### New Capabilities
+- `field-guide-discovery`: Reusable Field Guide regions and route mappings, collectible catalog management, probabilistic walk-triggered discovery, immutable duplicate collection, Field Guide presentation, and first-discovery map markers.
+
+### Modified Capabilities
+None.
+
+## Impact
+
+- D1 schema: new tables for Field Guide regions, storyline-region distance mappings, collectible definitions, user discovery instances, and last-visit or unread-count support as needed for badge behavior.
+- Worker APIs: new admin CRUD and mapping endpoints, public Field Guide list/detail/status endpoints, and progress-handler hooks to evaluate discovery rolls on walk create/update flows.
+- Frontend: new SSR Field Guide page plus Preact island, Drawer navigation badge updates, Konva map marker layer for first discoveries, and supporting client stores.
+- Cross-change coordination: should align with the active events-and-challenges and storyline-books-and-achievements changes for immutable repeatable-achievement infrastructure, progress-hook sequencing, and route-aware presentation rules.
+- Rendering and content: should reuse the existing Markdown rendering and image-management patterns where possible without coupling discovery to goal unlock behavior.
+- Testing and docs: requires Jest, Vitest, and Playwright coverage plus updates to data model, API, frontend, architecture, and asset workflow docs.

--- a/openspec/changes/field-guide-collectible-discovery/specs/field-guide-discovery/spec.md
+++ b/openspec/changes/field-guide-collectible-discovery/specs/field-guide-discovery/spec.md
@@ -1,0 +1,135 @@
+## ADDED Requirements
+
+### Requirement: Field Guide collection is global and region-based
+The system SHALL provide one global Field Guide collection per user across all storylines, where reusable regions are authored once and can be mapped to one or more storyline distance bands.
+
+#### Scenario: Same region appears on multiple storylines
+- **GIVEN** an admin has mapped the same reusable region to multiple storylines at different distance bands
+- **WHEN** a user views the Field Guide
+- **THEN** the system shows one shared region section for that region rather than separate per-storyline copies
+
+#### Scenario: Discovery persists across storyline switches
+- **GIVEN** a user has discovered collectibles in a reusable region on one storyline
+- **WHEN** the user switches to another storyline that also maps that same region
+- **THEN** the previously discovered slots in that region remain revealed in the global Field Guide
+
+### Requirement: Admins can manage regions, mappings, and collectible catalog entries
+The system SHALL provide admin workflows to manage reusable Field Guide regions, storyline-to-region distance mappings, and collectible catalog entries for those regions.
+
+#### Scenario: Admin defines a reusable region mapping
+- **GIVEN** an admin is configuring Field Guide data
+- **WHEN** the admin maps a reusable region to a storyline with a start and end distance band
+- **THEN** the system saves that mapping independently of the region definition itself
+
+#### Scenario: Admin creates a collectible slot
+- **GIVEN** an admin is editing a reusable region
+- **WHEN** the admin creates a collectible entry
+- **THEN** the system requires a category of either `flora` or `fauna`, a rarity tier, a fixed slot order, and the authored content needed for that collectible's silhouette and revealed detail view
+
+### Requirement: Positive walk distance triggers region-aware discovery attempts
+The system SHALL evaluate collectible discovery only from positive walk distance added through walk create or walk update flows, using the active storyline's mapped regions across the traversed distance interval and rarity-tier-based odds with a slight rare-tier bump for unusually long walk entries.
+
+#### Scenario: New walk entry creates discovery attempts
+- **GIVEN** a user logs a new walk entry with positive distance
+- **WHEN** the entry is saved successfully
+- **THEN** the system evaluates discovery attempts from that positive distance against the mapped regions traversed by the user on the active storyline
+
+#### Scenario: Walk update only uses newly added distance
+- **GIVEN** a user has already saved a walk entry for a date
+- **WHEN** the user increases that entry's distance later
+- **THEN** the system evaluates discovery attempts only for the newly added distance above that date's previously processed high-water mark
+
+#### Scenario: Crossing multiple mapped regions can yield discoveries from each
+- **GIVEN** a saved walk entry moves the user through more than one mapped region band on the active storyline
+- **WHEN** discovery attempts are evaluated
+- **THEN** the system uses the traversed interval to make collectibles from each crossed mapped region eligible
+
+#### Scenario: Long walk entries slightly improve rare finds
+- **GIVEN** a saved walk entry meets the long-walk threshold
+- **WHEN** discovery attempts are evaluated
+- **THEN** the system applies a slight bump toward rarer collectible tiers compared with an otherwise equivalent shorter walk entry
+
+### Requirement: Discoveries are immutable and duplicates are preserved
+The system SHALL store discoveries as immutable collection events, reveal a collectible slot on first discovery, preserve duplicates as additional finds of the same collectible, and never revoke already found collectibles because of later walk edits or deletes.
+
+#### Scenario: First discovery reveals a slot
+- **GIVEN** a user has not previously found a collectible
+- **WHEN** the user discovers that collectible for the first time
+- **THEN** the system reveals that collectible in its authored slot and records a duplicate count of `1`
+
+#### Scenario: Duplicate discovery increases count
+- **GIVEN** a user has already found a collectible
+- **WHEN** the user discovers the same collectible again
+- **THEN** the system increases that collectible's duplicate count without creating a second Field Guide slot
+
+#### Scenario: Walk reductions do not remove discoveries
+- **GIVEN** a user has already earned one or more discoveries
+- **WHEN** the user later reduces or deletes the walk entry that originally contributed to those discoveries
+- **THEN** the previously found collectibles remain in the user's collection
+
+#### Scenario: Existing users do not receive historical backfill
+- **GIVEN** a user already has pre-launch walking history when the feature is introduced
+- **WHEN** the Field Guide launches
+- **THEN** the user starts with no backfilled discoveries and can discover collectibles only through post-launch walking activity
+
+### Requirement: Field Guide page shows fixed silhouette slots and revealed details
+The system SHALL present a dedicated Field Guide experience with region sections in authored order, fixed collectible slots visible from the start as silhouettes, revealed art and lore for discovered collectibles, duplicate counts, progress indicators, and flora/fauna filtering.
+
+#### Scenario: Undiscovered slots are visible from the start
+- **GIVEN** a user has not yet found every collectible in a region
+- **WHEN** the user opens the Field Guide
+- **THEN** the system shows the region's full authored slot layout with undiscovered entries rendered as locked silhouettes
+
+#### Scenario: Discovered collectible shows detail view
+- **GIVEN** a user has discovered a collectible
+- **WHEN** the user opens that collectible from the Field Guide
+- **THEN** the system shows the collectible's illustration, name, category, rarity, region, duplicate count, and authored lore content
+
+#### Scenario: User filters the guide by category
+- **GIVEN** the Field Guide contains both flora and fauna entries
+- **WHEN** the user applies a `flora` or `fauna` filter
+- **THEN** the system limits the visible collectible results to that category while preserving each region's authored slot order
+
+### Requirement: Field Guide unread badge counts unseen discoveries and duplicates
+The system SHALL track Field Guide unread state server-side and SHALL count both first discoveries and duplicate finds that occurred since the user last viewed or marked the Field Guide as seen.
+
+#### Scenario: Duplicate find increments unread badge
+- **GIVEN** a user has already discovered a collectible and has previously cleared their Field Guide unread count
+- **WHEN** the user finds that same collectible again
+- **THEN** the system increments the Field Guide unread badge for that new duplicate discovery
+
+#### Scenario: Viewing the guide clears current unread discoveries
+- **GIVEN** a user has one or more unread Field Guide discoveries
+- **WHEN** the user visits the Field Guide and the system marks the collection as seen
+- **THEN** the unread badge resets until a later discovery occurs
+
+### Requirement: First discoveries appear as map markers on compatible paths
+The system SHALL show map markers for first-discovery locations only, using the path context recorded at the moment of first discovery, and SHALL not create additional map markers for later duplicates.
+
+#### Scenario: First discovery shows a marker on the matching path
+- **GIVEN** a user first discovered a collectible on a map path that matches the currently viewed storyline path
+- **WHEN** the user opens the map
+- **THEN** the system shows a marker for that collectible at its recorded first-discovery location
+
+#### Scenario: Duplicate discoveries do not create extra markers
+- **GIVEN** a user has already received a first-discovery map marker for a collectible
+- **WHEN** the user finds the same collectible again
+- **THEN** the system keeps the existing first-discovery marker and does not add another marker for that duplicate
+
+#### Scenario: Non-matching paths do not project markers onto another route
+- **GIVEN** a user's first discovery for a collectible was recorded on a different map path than the one currently being viewed
+- **WHEN** the user opens the current map path
+- **THEN** the system does not project that first-discovery marker onto the incompatible route
+
+### Requirement: Dev mode renders region distance bands on the map path
+The system SHALL render active storyline region distance bands as visual overlays on the map path when the existing map dev mode flag (`window.__MAP_DEV_LOG`) is enabled, so admins and developers can inspect mapping coverage and boundary placement during debugging and testing.
+
+#### Scenario: Dev mode shows region bands on the active path
+- **GIVEN** map dev mode is active and the active storyline has one or more mapped Field Guide region bands
+- **WHEN** the user opens the map
+- **THEN** the system renders visual indicators for each mapped region band along the rendered path
+
+#### Scenario: Dev mode off hides region bands
+- **GIVEN** map dev mode is not active
+- **WHEN** the user opens the map
+- **THEN** the system does not render region band overlays

--- a/openspec/changes/field-guide-collectible-discovery/tasks.md
+++ b/openspec/changes/field-guide-collectible-discovery/tasks.md
@@ -1,0 +1,43 @@
+## 1. Schema And Domain Foundations
+
+- [ ] 1.1 Add D1 migrations for reusable Field Guide regions, storyline-region distance mappings, collectible definitions, per-date discovery high-water state, immutable user discovery instances, and user unread state.
+- [ ] 1.2 Seed initial flora/fauna regions, reusable storyline mappings, and collectible catalog rows needed for the MVP launch set.
+- [ ] 1.3 Add strict TypeScript interfaces and data-access helpers for regions, mappings, collectibles, discovery instances, high-water state, unread state, and public/admin response shapes.
+- [ ] 1.4 Implement validation for region slugs, collectible categories, rarity tiers, slot ordering, and non-overlapping active mappings within a storyline.
+
+## 2. Discovery Engine And Progress Integration
+
+- [ ] 2.1 Extend walk create/update flows to load the previous saved distance, calculate the positive delta, and respect the per-date discovery high-water mark.
+- [ ] 2.2 Implement storyline-aware interval resolution so a positive walk delta is split across each mapped region band traversed during that save.
+- [ ] 2.3 Implement the distance-budget discovery engine with shared rarity-tier odds, a configured per-request attempt cap, and a long-walk rare-tier bump.
+- [ ] 2.4 Persist immutable discovery instances with storyline, path, and first-discovery distance context, and ensure deletes or negative updates never revoke discoveries.
+- [ ] 2.5 Isolate Field Guide post-write discovery processing alongside existing progress side effects so failures do not break the primary walk save flow.
+
+## 3. Admin APIs And Management UI
+
+- [ ] 3.1 Implement admin region CRUD endpoints plus storyline-mapping endpoints for reusable Field Guide regions.
+- [ ] 3.2 Implement admin collectible CRUD endpoints with validation for flora/fauna category, rarity tier, slot order, illustrations, and authored lore content.
+- [ ] 3.3 Add a dedicated admin Field Guide region management surface with mapping controls and gap/overlap validation feedback.
+- [ ] 3.4 Add a dedicated admin collectible management surface with slot ordering, content preview, and illustration selection workflow.
+
+## 4. Public Field Guide APIs And State
+
+- [ ] 4.1 Implement public Field Guide list and detail endpoints that return the global region collection, fixed slot roster, discovery state, duplicate counts, and category-filterable item data.
+- [ ] 4.2 Implement unread-status and mark-seen endpoints backed by server-side unread state so duplicates and first discoveries both contribute to the drawer badge.
+- [ ] 4.3 Implement public map-marker data for first discoveries, filtered to the currently viewed compatible path and derived from stored first-discovery context.
+
+## 5. User-Facing Field Guide And Map UI
+
+- [ ] 5.1 Add the `/field-guide` SSR shell, stylesheet wiring, and Preact island registration following existing page patterns.
+- [ ] 5.2 Build the Field Guide island with authored region order, fixed silhouette slots, discovered detail views, duplicate counts, progress indicators, and flora/fauna filters.
+- [ ] 5.3 Add the Drawer navigation link and unread badge behavior for the Field Guide.
+- [ ] 5.4 Add a Konva first-discovery marker layer on the map that shows only compatible-path first discoveries and does not add markers for duplicates.
+- [ ] 5.5 Add dev-mode region band overlays on the map path when `window.__MAP_DEV_LOG` is active, rendering each mapped region band visually for debugging and testing.
+
+## 6. Validation And Documentation
+
+- [ ] 6.1 Add Jest coverage for mapping validation, positive-delta/high-water discovery processing, multi-region traversal, immutable duplicate behavior, unread-state updates, and no-backfill rollout behavior.
+- [ ] 6.2 Add Vitest coverage for Field Guide region rendering, silhouettes, revealed details, duplicate counts, filters, unread badge behavior, and admin management forms.
+- [ ] 6.3 Add Playwright coverage for admin setup, post-launch discovery flow, duplicate unread counts, and first-discovery map marker rendering.
+- [ ] 6.4 Update `docs/data-models.md`, `docs/api-reference.md`, `docs/frontend-guide.md`, `docs/architecture.md`, and `docs/asset-workflow.md` for the Field Guide discovery model.
+- [ ] 6.5 Run focused backend, client, and UI validation commands and fix regressions related to the new schema, progress hooks, Field Guide UI, and map marker behavior.

--- a/openspec/changes/goal-content-campfire-lore/.openspec.yaml
+++ b/openspec/changes/goal-content-campfire-lore/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-30

--- a/openspec/changes/goal-content-campfire-lore/design.md
+++ b/openspec/changes/goal-content-campfire-lore/design.md
@@ -1,0 +1,143 @@
+## Context
+
+Walk to Mordor currently stores only a single authored description on each goal and renders it through the existing goal surfaces. The relevant implementation already spans several layers: goal data comes from storyline-aware goal queries in the Worker, the admin goal edit experience is a Preact island with Markdown preview, the journey goals list still uses legacy `public/js/goals.js`, and `GoalModal` is a shared Preact surface used for personal, map, and fellowship milestone views.
+
+This change is cross-cutting because it adds a new data model, expands goal API shapes, introduces admin CRUD, adds new display states to both legacy and island-based goal surfaces, and needs best-effort discovery analytics without making content reads or modal opens slower. The user has also clarified that content is not independently locked: if a goal is visible in a given context, its content is visible in that same context, and if a locked goal has content the UI should tease that fact instead of hiding it.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add authored rich content attached directly to goals with ordering, content type, Markdown body, and optional attribution.
+- Reuse the exact same unlock semantics as existing goal viewing in both personal and fellowship contexts.
+- Extend goal surfaces so goals with extra content advertise that fact, including blurred teaser placeholders for locked goals.
+- Add goal-content management to the existing admin goal editing flow instead of inventing a separate admin area.
+- Render unlocked content in `GoalModal` with distinct story, poetry, and appendix treatments.
+- Record lightweight discovery analytics without blocking user-facing reads or interactions.
+
+**Non-Goals:**
+- Introduce a separate content publishing workflow, moderation queue, or review system.
+- Create a standalone lore page outside goal-attached discovery.
+- Add strict Markdown authoring constraints beyond safe HTML sanitization.
+- Add automated lore or copyright validation.
+- Rewrite the legacy goals list into a fully new island architecture as part of this change.
+
+## Decisions
+
+### 1. Use a dedicated `goal_content` table plus a lightweight discovery-event table
+
+The change will add a `goal_content` table keyed to `goals.id` with `type`, `title`, `body`, `author_attribution`, and `sort_order`, plus timestamps. Ordering and uniqueness will be enforced by `UNIQUE(goal_id, sort_order)` because content is displayed as one ordered sequence per goal regardless of type.
+
+Validation limits will be intentionally simple:
+- `title`: max 120 characters
+- `author_attribution`: max 255 characters
+- `body`: max 20,000 characters for all content types
+- `sort_order`: integer from 0 to 999
+
+The body limit is shared across story, poetry, and appendix entries rather than type-specific because the user explicitly prefers giving content authors room to use the longer limit when needed.
+
+For lightweight discovery metrics, the change will add a second append-only table such as `content_discovery_events` with columns for `id`, `user_id` nullable, `party_id` nullable, `goal_id`, `content_id` nullable, `event_type`, `context_type`, and `created_at`.
+
+Alternatives considered:
+- Reusing `goals.description` for all content types was rejected because it cannot model multiple ordered entries per goal.
+- `UNIQUE(goal_id, type, sort_order)` was rejected because it allows order collisions between types while the UI renders a single ordered stream.
+- Type-specific body caps were rejected because they create needless editorial constraints without a clear UX benefit.
+
+### 2. Use current app naming and goal-scoped routes
+
+The API and admin surfaces will use current app names consistently:
+- Admin: `/api/admin/goals/:goalId/content`
+- Public: `/api/goals/:goalId/content`
+
+This aligns with the existing route vocabulary and avoids mixing `milestone` and `goal` terminology inside the same change.
+
+Alternatives considered:
+- Using `milestones` in routes was rejected because the codebase, admin pages, and existing APIs are already goal-centric.
+
+### 3. Reuse existing goal unlock semantics exactly, including fellowship context
+
+There will be no separate content locking mechanism. The Worker will reuse the same unlock logic already implied by goal viewing in the relevant context:
+- Personal reads use the active user's storyline-aware displayed distance against the storyline goal distance for the requested goal.
+- Fellowship reads use the same fellowship progress context that currently allows a party milestone to be viewed.
+
+To preserve this behavior without inventing a parallel endpoint family, the public content route will support an optional `partyId` query parameter. Without `partyId`, the route evaluates personal progress. With `partyId`, it evaluates fellowship progress for that requesting user and party.
+
+Alternatives considered:
+- Using canonical `goals.distance` was rejected because goals are already storyline-aware through `storyline_goals`.
+- A separate fellowship content endpoint was rejected because the behavior is the same and only the unlock context changes.
+
+### 4. Expose `has_content` on goal responses and derive teaser UI client-side
+
+`GET /api/goals` will add `has_content: boolean` for any goal that has one or more `goal_content` rows, regardless of whether the goal is currently unlocked. This is intentional: the product wants upcoming goals to hint that additional content exists.
+
+The client will derive teaser behavior from two facts it already has or can infer:
+- `has_content`
+- whether the goal is locked in the current context
+
+Locked goals with `has_content = true` will show a blurred or obscured teaser placeholder wherever extra goal content is surfaced, rather than the real content.
+
+Alternatives considered:
+- Hiding content existence for locked goals was rejected because it conflicts with the desired incentive mechanic.
+- Returning a more complex content preview payload in `/api/goals` was rejected to keep the list API lightweight and SWR-friendly.
+
+### 5. Extend existing goal surfaces instead of creating parallel UI
+
+Admin authoring will be added to `AdminGoalEditIsland`, reusing its existing Markdown preview pattern with `marked` and `DOMPurify`.
+
+Public presentation will extend `GoalModal` for unlocked content, while goal list and card surfaces will only show teaser state and a lightweight indicator of additional content. Because the journey goal list is still hybrid, the implementation must touch both:
+- legacy `public/js/goals.js`
+- Preact `NextGoalCard` and `UpcomingGoalCard`
+
+This avoids a broad rewrite while still giving new content a first-class UI path.
+
+Alternatives considered:
+- Building a dedicated admin content page was rejected because goal content is edited in the context of a single goal.
+- Rewriting the legacy goals list was rejected as too large for the scope of this change.
+
+### 6. Use permissive Markdown rendering with sanitization
+
+Goal content bodies will render through the existing client-side stack of `marked` followed by `DOMPurify`. The goal is editorial flexibility rather than a tightly restricted Markdown dialect, but rendered HTML will still be sanitized before insertion into the DOM.
+
+Alternatives considered:
+- Plain-text-only content was rejected because authored lore benefits from headings, emphasis, lists, and block quotes.
+- Unsanitized Markdown HTML was rejected because admin-authored content is still user-entered content from the browser's point of view.
+
+### 7. Define appendix truncation by stripped-text word count
+
+Appendix entries will default to collapsed when the rendered content exceeds 500 words, measured using plain text derived from the Markdown body after stripping markup. Stories and poetry will not use this truncation rule.
+
+Alternatives considered:
+- Counting raw Markdown characters was rejected because markup noise distorts what the user actually reads.
+- Server-side truncation was rejected because the user explicitly wants client-side expand/collapse behavior.
+
+### 8. Record discovery analytics as best-effort background writes
+
+Content discovery events should never block content reads, modal rendering, or goal list loads. The design therefore assumes a best-effort logging path using `ctx.waitUntil(...)` from the Worker request lifecycle, with failures swallowed after logging.
+
+That implies a small Worker plumbing change: the `fetch` handler in `src/index.ts` will need to accept `ctx: ExecutionContext` so relevant routes can schedule analytics writes after the response is created.
+
+Alternatives considered:
+- Synchronous analytics writes were rejected because they would add latency and create new failure modes on read-only user actions.
+- Fully client-only analytics with no persistence was rejected because the success metric needs durable aggregated events.
+
+## Risks / Trade-offs
+
+- [Hybrid UI duplication] → The teaser state must be implemented in both legacy goal rendering and Preact goal cards. Mitigation: keep the API contract minimal (`has_content`) and share styling tokens and naming.
+- [Unlock-context ambiguity] → Personal and fellowship views can unlock the same goal through different distance contexts. Mitigation: make the public content read endpoint explicitly context-aware via optional `partyId`.
+- [Background analytics may drop events] → Best-effort writes can be lost if the Worker is interrupted. Mitigation: accept eventual undercounting as preferable to slowing user interactions.
+- [Permissive Markdown can produce inconsistent author output] → Flexible content may vary visually more than goal descriptions do today. Mitigation: sanitize HTML and constrain presentation through content-type-specific container styles.
+- [Expanded `/api/goals` shape is SWR-cached] → Clients may briefly hold stale `has_content` booleans after admin edits. Mitigation: keep cache-version and stale-while-revalidate behavior as-is; correctness self-heals on background refresh.
+
+## Migration Plan
+
+1. Add an additive migration for `goal_content` and an additive migration for `content_discovery_events`.
+2. Deploy Worker route changes and goal API shape changes.
+3. Deploy admin and public UI changes that consume the new fields and endpoints.
+4. Update docs and tests together so the new route and schema expectations are documented before implementation is applied.
+
+Rollback strategy:
+- Because the schema additions are additive, rollback can disable the new routes and UI without needing to delete data.
+- If the public UI must be rolled back, `has_content` can remain present but unused until the feature is re-enabled.
+
+## Open Questions
+
+None blocking. The user has already resolved the main scope decisions around naming, teaser visibility, unlock semantics, analytics behavior, and content limits.

--- a/openspec/changes/goal-content-campfire-lore/proposal.md
+++ b/openspec/changes/goal-content-campfire-lore/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Walk to Mordor currently treats goal descriptions as the only authored milestone reward, which limits how much narrative payoff a reached goal can provide. Epic 16 adds richer goal-attached lore so unlocked goals can feel more rewarding, while locked goals with extra content can tease that reward and create additional motivation to keep walking.
+
+## What Changes
+
+- Introduce authored rich content attached directly to goals, covering campfire stories, poetry, and appendices.
+- Add admin management for goal content inside the existing goal editing flow, including Markdown authoring, ordering, preview, and content-type metadata.
+- Add public goal content APIs that reuse the exact same unlock state as the goal surface itself, including fellowship progress contexts where the goal is already viewable.
+- Extend goal list and card surfaces so goals with extra content advertise that fact, including blurred teaser placeholders for still-locked goals.
+- Add GoalModal content presentation for unlocked content with type-aware rendering for stories, poetry, and appendices, including long-form appendix truncation.
+- Add lightweight best-effort discovery analytics for teaser impressions and content opens.
+
+## Capabilities
+
+### New Capabilities
+- `goal-content`: Authored content attached to goals, including admin management, goal-context unlock behavior, goal-card teasers, modal rendering, and lightweight discovery analytics.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- D1 schema: new goal content table and lightweight content discovery event table.
+- Worker APIs: new admin goal-content CRUD endpoints, new public goal-content read endpoints, and `/api/goals` response expansion for content presence.
+- Frontend: updates to the existing admin goal editor, goal cards, legacy goals list rendering, and GoalModal content display.
+- Dependencies and rendering: reuse existing `marked` and `DOMPurify` client-side Markdown pipeline rather than introducing a separate authoring system.
+- Testing and docs: new Jest, Vitest, and Playwright coverage plus updates to API, data-model, architecture, and frontend documentation.

--- a/openspec/changes/goal-content-campfire-lore/specs/goal-content/spec.md
+++ b/openspec/changes/goal-content-campfire-lore/specs/goal-content/spec.md
@@ -1,0 +1,193 @@
+## ADDED Requirements
+
+### Requirement: Admins can manage ordered goal content entries
+The system SHALL allow authenticated admins to list, create, update, and delete authored content entries attached directly to a goal, with each entry storing a content type, title, Markdown body, optional attribution, and sort order.
+
+#### Scenario: Admin lists content for a goal
+- **WHEN** an authenticated admin requests content for a goal
+- **THEN** the system returns that goal's content entries ordered by `sort_order` ascending
+
+#### Scenario: Admin creates a content entry
+- **GIVEN** an authenticated admin is editing a goal
+- **WHEN** the admin creates a valid content entry with type, title, body, and sort order
+- **THEN** the system stores the entry for that goal and returns the created content record
+
+#### Scenario: Duplicate sort order is rejected for a goal
+- **GIVEN** a goal already has a content entry with sort order `2`
+- **WHEN** an authenticated admin creates or updates another content entry on that same goal with sort order `2`
+- **THEN** the system rejects the request
+
+#### Scenario: Field limits are enforced
+- **WHEN** an authenticated admin submits a content entry with a title longer than 120 characters, an attribution longer than 255 characters, a body longer than 20,000 characters, or a sort order outside the allowed range
+- **THEN** the system rejects the request
+
+#### Scenario: Non-admin cannot manage goal content
+- **WHEN** an authenticated non-admin user calls a goal-content admin endpoint
+- **THEN** the system denies the request
+
+### Requirement: Goal content reuses existing goal unlock behavior
+The system SHALL use the exact same goal unlock state as the relevant goal surface when deciding whether authored goal content is viewable, with no separate content-specific locking or unlocking mechanism.
+
+#### Scenario: Personal goal unlock also unlocks goal content
+- **GIVEN** a goal is unlocked for the active user in personal view
+- **WHEN** the user requests content for that goal
+- **THEN** the system returns the goal's authored content entries
+
+#### Scenario: Fellowship goal unlock also unlocks goal content
+- **GIVEN** a goal is viewable in a fellowship context because the fellowship has already unlocked that goal
+- **WHEN** a member requests content for that goal in that fellowship context
+- **THEN** the system returns the same authored content entries for that goal
+
+#### Scenario: Locked goal content is not returned as unlocked content
+- **GIVEN** a goal is still locked in the requested viewing context
+- **WHEN** the user requests content for that goal
+- **THEN** the system denies access to the unlocked content payload
+
+#### Scenario: Goal with no content returns an empty list
+- **GIVEN** a goal is unlocked in the requested viewing context
+- **WHEN** the user requests content for that goal and no content entries exist
+- **THEN** the system returns an empty array
+
+### Requirement: Goal list responses advertise content presence
+The system SHALL include content-presence state on goal list responses so goal surfaces can hint when a goal has additional authored content, including for goals that are still locked.
+
+#### Scenario: Goal with authored content reports content presence
+- **WHEN** the goal list is requested
+- **THEN** each goal that has one or more authored content entries includes `has_content = true`
+
+#### Scenario: Goal without authored content reports no content presence
+- **WHEN** the goal list is requested
+- **THEN** each goal with no authored content includes `has_content = false`
+
+#### Scenario: Locked goal can still advertise extra content
+- **GIVEN** a goal is locked in the current viewing context
+- **AND** that goal has authored content
+- **WHEN** the goal list is rendered
+- **THEN** the UI can detect that extra content exists without receiving the unlocked content body itself
+
+### Requirement: Locked goals tease extra content without revealing it
+The system SHALL show a blurred or obscured teaser placeholder for additional goal content on locked goal surfaces when `has_content = true`, so users can tell that more content exists without reading the actual content before the goal unlocks.
+
+#### Scenario: Locked goal with content shows teaser placeholder
+- **GIVEN** a goal is locked in the current viewing context
+- **AND** the goal has authored content
+- **WHEN** the goal surface renders
+- **THEN** the UI shows a blurred or obscured placeholder where additional content would otherwise appear
+
+#### Scenario: Locked goal without content shows no teaser placeholder
+- **GIVEN** a goal is locked in the current viewing context
+- **AND** the goal has no authored content
+- **WHEN** the goal surface renders
+- **THEN** the UI does not show an additional-content teaser placeholder
+
+#### Scenario: Unlocked goal does not use teaser placeholder
+- **GIVEN** a goal is unlocked in the current viewing context
+- **AND** the goal has authored content
+- **WHEN** the goal surface renders
+- **THEN** the UI shows the unlocked content experience instead of a blurred teaser placeholder
+
+### Requirement: GoalModal displays unlocked goal content
+The system SHALL load and render authored goal content inside the existing goal detail experience when a goal is unlocked and has content, while hiding the unlocked content section when no content exists.
+
+#### Scenario: GoalModal loads content when opened
+- **GIVEN** a goal has authored content and is unlocked in the current viewing context
+- **WHEN** the user opens the goal detail modal
+- **THEN** the client requests that goal's content from the goal-content API
+
+#### Scenario: Loading state is shown while content loads
+- **GIVEN** the goal detail modal has requested goal content
+- **WHEN** the response has not yet returned
+- **THEN** the modal shows a loading placeholder for the content area
+
+#### Scenario: Content section is hidden when no content exists
+- **GIVEN** a goal is unlocked in the current viewing context
+- **AND** the goal has no authored content
+- **WHEN** the goal detail modal renders
+- **THEN** the goal-content section is hidden
+
+#### Scenario: Multiple content entries display in configured order
+- **GIVEN** a goal has multiple authored content entries
+- **WHEN** the goal detail modal renders unlocked content
+- **THEN** the entries are displayed in ascending `sort_order`
+
+### Requirement: Goal content renders with type-specific presentation
+The system SHALL render authored goal content as safe HTML with presentation that varies by content type, while preserving one shared ordered content stream for the goal.
+
+#### Scenario: Story entries render as campfire stories
+- **GIVEN** an unlocked goal has a content entry of type `story`
+- **WHEN** the content is displayed
+- **THEN** the story uses the story presentation treatment for campfire lore
+
+#### Scenario: Poetry entries render as poems
+- **GIVEN** an unlocked goal has a content entry of type `poetry`
+- **WHEN** the content is displayed
+- **THEN** the poem uses centered, stanza-friendly presentation distinct from story entries
+
+#### Scenario: Appendix entries render as reference content
+- **GIVEN** an unlocked goal has a content entry of type `appendix`
+- **WHEN** the content is displayed
+- **THEN** the appendix uses a structured long-form presentation distinct from story and poetry entries
+
+#### Scenario: Markdown renders as sanitized HTML
+- **GIVEN** an unlocked goal has Markdown-authored content
+- **WHEN** the content is rendered in the browser
+- **THEN** the Markdown is converted to HTML and sanitized before insertion into the DOM
+
+#### Scenario: Type badges are shown for rendered entries
+- **GIVEN** an unlocked goal has one or more content entries
+- **WHEN** the entries are displayed
+- **THEN** each entry shows its content type badge
+
+### Requirement: Long appendices support truncation and attribution
+The system SHALL collapse appendix entries longer than 500 words by default, provide a user-controlled expand action, and render attribution when present.
+
+#### Scenario: Short appendix renders fully expanded
+- **GIVEN** an appendix entry contains 500 words or fewer
+- **WHEN** the content is displayed
+- **THEN** the appendix body is shown without a truncation control
+
+#### Scenario: Long appendix renders collapsed by default
+- **GIVEN** an appendix entry contains more than 500 words
+- **WHEN** the content is displayed
+- **THEN** the appendix body is initially truncated and shows an expand control
+
+#### Scenario: User expands a long appendix
+- **GIVEN** a long appendix is initially truncated
+- **WHEN** the user activates the expand control
+- **THEN** the full appendix body becomes visible
+
+#### Scenario: Attribution renders when present
+- **GIVEN** an appendix entry has author attribution text
+- **WHEN** the content is displayed
+- **THEN** the attribution is shown beneath that entry's body
+
+### Requirement: Admin authoring reuses Markdown preview in the existing goal editor
+The system SHALL let admins manage goal content from the existing goal editing experience and SHALL provide a Markdown preview during authoring.
+
+#### Scenario: Admin edits goal content from the goal edit page
+- **GIVEN** an authenticated admin opens the existing goal edit page
+- **WHEN** the admin manages authored content for that goal
+- **THEN** the content controls appear in the goal edit experience rather than a separate admin page
+
+#### Scenario: Markdown preview is available while authoring
+- **GIVEN** an authenticated admin is editing a goal content entry
+- **WHEN** the admin switches from edit mode to preview mode
+- **THEN** the UI shows a rendered preview of the Markdown body
+
+### Requirement: Goal content discovery events are recorded best-effort
+The system SHALL record lightweight best-effort discovery analytics for goal-content teasers and content opens without blocking the user-facing action that triggered the event.
+
+#### Scenario: Teaser impression is recorded
+- **GIVEN** a goal surface renders a locked teaser placeholder for additional content
+- **WHEN** that teaser becomes visible to the user
+- **THEN** the system records a teaser-impression discovery event on a best-effort basis
+
+#### Scenario: Content open is recorded
+- **GIVEN** a goal with authored content is opened in an unlocked context
+- **WHEN** the user opens or reveals the unlocked content experience
+- **THEN** the system records a content-open discovery event on a best-effort basis
+
+#### Scenario: Discovery logging failure does not block the user flow
+- **GIVEN** a goal-content discovery event cannot be written
+- **WHEN** the related goal surface still renders or opens
+- **THEN** the user-facing action succeeds even though the discovery event was not persisted

--- a/openspec/changes/goal-content-campfire-lore/tasks.md
+++ b/openspec/changes/goal-content-campfire-lore/tasks.md
@@ -1,0 +1,35 @@
+## 1. Schema And Data Access
+
+- [ ] 1.1 Add D1 migrations for `goal_content` and `content_discovery_events`, including constraints, indexes, and ordered uniqueness by `(goal_id, sort_order)`.
+- [ ] 1.2 Add strict TypeScript row types and database access helpers for goal content records and discovery event writes.
+
+## 2. Worker APIs And Unlock Logic
+
+- [ ] 2.1 Implement admin goal-content list/create/update/delete handlers with validation for type, title, attribution, shared body limit, and sort order.
+- [ ] 2.2 Wire admin goal-content routes and allowed methods in `src/index.ts`.
+- [ ] 2.3 Implement the public goal-content read endpoint with personal and `partyId`-aware unlock checks that reuse existing goal visibility semantics.
+- [ ] 2.4 Extend `GET /api/goals` to include `has_content` without changing existing goal ordering or lock behavior.
+- [ ] 2.5 Plumb `ExecutionContext` through the Worker request flow so goal-content analytics can be scheduled with non-blocking background writes.
+
+## 3. Admin Authoring Experience
+
+- [ ] 3.1 Extend the existing admin goal edit island to list ordered content entries and support create, edit, delete, and reorder actions in-place.
+- [ ] 3.2 Reuse the existing Markdown preview flow for goal-content bodies and surface validation errors clearly in the admin form.
+
+## 4. Public Goal Surfaces
+
+- [ ] 4.1 Update `GoalModal` to fetch goal content, show a loading state, render unlocked entries in `sort_order`, and hide the section when no content exists.
+- [ ] 4.2 Add type-specific rendering treatments for story, poetry, and appendix entries, including appendix attribution and 500-word expand/collapse behavior.
+- [ ] 4.3 Update legacy and island-based goal list/card surfaces to use `has_content` for locked teaser placeholders without exposing unlocked bodies.
+
+## 5. Discovery Analytics And UX Hardening
+
+- [ ] 5.1 Record best-effort teaser-impression and content-open discovery events without blocking the related user flow.
+- [ ] 5.2 Verify the new `has_content` and goal-content fetch behavior works cleanly with existing cache/versioning expectations and fallback states.
+
+## 6. Validation And Documentation
+
+- [ ] 6.1 Add backend tests covering goal-content validation, admin permissions, ordered persistence, personal unlock checks, fellowship unlock checks, and analytics failure tolerance.
+- [ ] 6.2 Add frontend tests covering admin Markdown preview, locked teaser rendering, unlocked content rendering, and appendix truncation behavior.
+- [ ] 6.3 Add Playwright coverage for admin authoring and user-facing locked versus unlocked goal-content flows.
+- [ ] 6.4 Update the relevant docs in `docs/` for the new schema, APIs, frontend behavior, and testing expectations.

--- a/openspec/changes/goal-milestone-journals/.openspec.yaml
+++ b/openspec/changes/goal-milestone-journals/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-30

--- a/openspec/changes/goal-milestone-journals/design.md
+++ b/openspec/changes/goal-milestone-journals/design.md
@@ -1,0 +1,130 @@
+## Context
+
+Walk to Mordor already renders milestone details through one shared `GoalModal`, but the goal data feeding that modal is hybrid: legacy journey goals come from `public/js/goals.js`, newer surfaces come from Preact islands, and fellowship milestone views use separate progress endpoints. The app also no longer treats goals as a single linear route. `storyline_goals` reuses canonical `goals` rows at different distances on different storylines, which means journals cannot be keyed to storyline-specific distances if users are meant to share Rivendell notes across Frodo/Sam and Pippin.
+
+This change is cross-cutting because it adds new D1 data, new Worker routes, new access-control rules that depend on both friendships and milestone visibility preferences, and GoalModal state that must work in personal, map, walk-congratulations, and fellowship contexts. The user has also narrowed MVP scope: no dedicated My Journal page, no archive flow, and no separate journal browsing surface outside GoalModal.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Store one plain-text journal entry per user per canonical shared goal.
+- Show the same entry across every storyline that reuses that goal.
+- Allow individual authoring when the user has reached the goal personally or when the fellowship they are actively viewing has reached it.
+- Let GoalModal read the viewer's own entry plus visible friend entries in one request shape that supports the MVP UI directly.
+- Apply the user-selected milestone visibility rule to friend-entry reads when previews are locked, while keeping journals plain text and safe to render.
+- Reuse the repo's existing Cloudflare Worker, D1, Preact island, and legacy goals patterns without rewriting the journey goals list.
+
+**Non-Goals:**
+- No standalone `/journals` page, profile journal archive, or journal list endpoint for MVP.
+- No Markdown or rich-text authoring for journal bodies.
+- No admin journal management surface.
+- No journal analytics or goal-list badges in MVP.
+- No per-storyline duplicate journal entries for the same shared goal.
+
+## Decisions
+
+### 1. Journal identity is canonical `goal_id`, not `storyline_goal_id`
+
+`milestone_journals` will be unique on `(user_id, goal_id)`. A journal entry written at Rivendell on one storyline is the same entry shown when that same canonical goal appears on another storyline.
+
+Rationale: the user explicitly wants shared-goal journals across storylines. The repo's storyline system already treats `goals` as reusable canonical milestones and `storyline_goals` as route-specific placement.
+
+Alternatives considered:
+- Keying journals by `storyline_goal_id` was rejected because it would create duplicate entries for the same shared destination across storylines.
+- Storing both `goal_id` and `storyline_goal_id` in the uniqueness constraint was rejected because it would weaken the cross-storyline sharing rule.
+
+### 2. Use goal-scoped modal APIs instead of generic journal collections in MVP
+
+The MVP API surface will be optimized for GoalModal rather than for a future journal archive page:
+- `GET /api/goals/:goalId/journals[?partyId=<id>]` returns the viewer's current journal state for that goal: own entry, visible friend entries, and permission flags needed by GoalModal.
+- `PUT /api/goals/:goalId/journal` creates or updates the current user's single journal entry for that goal. Request body includes `body`, `visibility`, and optional `partyId` for fellowship-context write validation.
+- `DELETE /api/goals/:goalId/journal` deletes the current user's entry for that goal.
+
+Rationale: there is no My Journal page in MVP, and the modal needs both own-entry state and friend-entry state together. Goal-scoped endpoints avoid extra lookups, avoid journal-id routing churn, and match the one-entry-per-user-per-goal model cleanly.
+
+Alternatives considered:
+- Preserving the original `POST /api/journals`, `PUT /api/journals/:id`, `GET /api/journals/mine`, and friends-list endpoints was rejected because it adds round trips and list APIs the MVP will not use.
+- A separate `journal-state` endpoint was rejected because the goal-scoped journals route already conveys the right resource context.
+
+### 3. Separate write access from friend-read access, and make both context-aware
+
+Write access and friend-read access will be computed independently.
+
+Write access:
+- Allowed when the user has personally reached the canonical goal in their active storyline context.
+- Also allowed when the request includes `partyId`, the user is an active member of that fellowship, and the fellowship has reached the same canonical goal in that fellowship storyline context.
+
+Friend-read access:
+- Requires accepted friendship in every case.
+- If the viewer has milestone previews locked, then the viewer must also have reached the goal in the current reading context before friend entries are returned.
+- If the viewer has milestone previews enabled, accepted friendship alone is sufficient for friend-entry reads.
+
+Rationale: this matches the user's clarified product rules and keeps fellowship progress meaningful without forcing users to switch back to personal view just to write.
+
+Alternatives considered:
+- Requiring personal reach only for writes was rejected because it conflicts with the clarified fellowship-first play style.
+- Requiring viewer reach for every friend read was rejected because the user explicitly wants friendship-only reads when previews are enabled.
+- Friendship-only reads in all cases were rejected because they would bypass the viewer's locked-milestone preference.
+
+### 4. Return permission flags with the journal-state response
+
+The goal-scoped read response will include permission booleans such as `canWrite`, `canEditOwn`, `canDeleteOwn`, and `canReadFriends`, plus the viewer's own entry if present and the currently visible friend entries.
+
+Rationale: GoalModal is the only MVP surface. Returning permission state directly keeps the UI deterministic across legacy and island entry points and prevents it from re-deriving complex friendship, preview, and fellowship access rules client-side.
+
+Alternatives considered:
+- Making the client infer permissions from raw session and preference state was rejected because modal callers do not all carry the same context.
+- Returning 403 for hidden friend entries was rejected because GoalModal still needs to render the rest of the milestone normally.
+
+### 5. Keep journal bodies plain text and render them as text, not HTML
+
+Journal bodies will be trimmed, validated as non-empty plain text up to 2000 characters, and rendered as text nodes with line breaks preserved via `white-space: pre-wrap`. The body itself will never be inserted with `dangerouslySetInnerHTML`.
+
+This change will still follow the sanitization posture established in the adjacent goal-content change: any future helper-generated HTML wrappers or excerpt rendering must use the same safe client-side sanitization standards already being adopted there, but the journal body itself remains plain text only.
+
+Rationale: plain text avoids moderation and XSS complexity while still preserving the safe-rendering standard the repo is converging on.
+
+Alternatives considered:
+- Escaping or HTML-encoding on storage was rejected because it couples persistence to presentation and makes future rendering rules harder to reason about.
+- Supporting Markdown was rejected because the user explicitly kept journals plain text.
+
+### 6. GoalModal is the only MVP journal surface
+
+This change will extend the shared `GoalModal` used by journey, map, walk-congratulations, and fellowship milestone surfaces. It will not add a My Journal page, profile journal section, or separate browsing flow in MVP.
+
+Rationale: this keeps scope focused on the moment a milestone is experienced and avoids introducing list APIs or archive navigation that the user deferred.
+
+Alternatives considered:
+- Adding `/journals` in the same change was rejected because the user explicitly moved it to post-MVP.
+- Embedding journal browsing in the profile page was rejected because profile is currently a settings-focused surface, not a content archive.
+
+### 7. Preserve modal context explicitly across callers
+
+Client goal models and modal props will need to preserve enough context for journal reads and writes, specifically canonical `goal_id`, optional `storyline_goal_id`, and optional `partyId` when the modal is opened from a fellowship surface.
+
+Rationale: several current adapters reconstruct lightweight goal objects and would otherwise lose the context needed for correct write validation and friend-read gating.
+
+Alternatives considered:
+- Letting GoalModal rediscover all context from global state was rejected because not every caller participates in the same state layer.
+
+## Risks / Trade-offs
+
+- [Shared goals at different storyline distances may surprise users] → Mitigation: treat the journal as belonging to the canonical destination, not the distance marker, and keep wording in docs and tests aligned with that model.
+- [GoalModal callers currently drop context fields] → Mitigation: update shared goal typings and modal props before wiring journal fetches so every caller carries canonical goal and optional fellowship context consistently.
+- [Friend-read rules depend on user preference state] → Mitigation: compute permission flags server-side and let the UI hide the friends section when `canReadFriends` is false.
+- [Concurrent GoalModal changes from adjacent content work] → Mitigation: keep the journal state contract self-contained and coordinate around a single modal fetch lifecycle rather than separate duplicated loaders.
+- [Fellowship-based write access can outlive later personal progress changes] → Mitigation: journal ownership is personal and durable once created; only creation and updates are gated by current access rules.
+
+## Migration Plan
+
+1. Add an additive D1 migration for `milestone_journals` with uniqueness, visibility validation, timestamps, and indexes optimized for goal-scoped reads.
+2. Add Worker journal handlers and route-method registration in `src/index.ts`.
+3. Widen shared goal and modal context types so GoalModal can receive canonical goal identity plus optional fellowship context.
+4. Extend GoalModal to fetch goal-scoped journal state, render own-entry authoring or read mode, and show visible friend entries.
+5. Add backend, client, and Playwright coverage, then update data-model, API, frontend, and architecture docs.
+
+Rollback strategy: the schema addition is additive. If the UI or routes must be rolled back, the Worker can stop exposing the journal endpoints and the modal can stop fetching journal state without requiring data deletion.
+
+## Open Questions
+
+None blocking for MVP. Future work can decide whether to surface route-origin metadata, journal archive browsing, or goal-list journal indicators once the modal-first flow is established.

--- a/openspec/changes/goal-milestone-journals/proposal.md
+++ b/openspec/changes/goal-milestone-journals/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Walk to Mordor already makes milestones feel social, but users still cannot leave their own reflections at the places they reach together. This change adds personal milestone journals so shared goals become shared storytelling moments, while fitting the repo's storyline-aware goal model and existing GoalModal experience.
+
+## What Changes
+
+- Introduce plain-text milestone journal entries stored once per user per canonical goal and shared across all storylines that reuse that goal.
+- Add authenticated journal APIs for create, update, delete, own-entry reads, and friends' journal reads, with access rules derived from friendship, milestone visibility, and viewing context.
+- Allow a user to create an individual journal entry when they have reached the goal personally or when an active fellowship context they are viewing has reached the same goal.
+- Extend GoalModal to load the viewer's own journal state and friends' journals for the current goal, with character counting, visibility controls, safe plain-text rendering, and no standalone My Journal page in MVP.
+- Reuse existing safe text and HTML sanitization patterns already adopted in adjacent goal-content work, while keeping journal bodies plain text only.
+- Preserve compatibility across the app's hybrid goal surfaces, including legacy journey goals, map goal modals, walk congratulations, and fellowship milestone modals.
+
+## Capabilities
+
+### New Capabilities
+- `goal-journals`: Plain-text user journal entries attached to canonical goals, including storyline-shared identity, personal and fellowship write access, friends-only visibility rules, and GoalModal reading and authoring for MVP.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- D1 schema: new `milestone_journals` table and supporting indexes, with journal identity centered on canonical `goal_id` so shared goals work across storylines.
+- Worker APIs: new journal routes, route-method registration updates in `src/index.ts`, and storyline-aware plus fellowship-aware access checks.
+- Frontend: `GoalModal` becomes the MVP journal surface across personal, map, and fellowship entry points; no dedicated `/journals` page or profile journal archive is included in this change.
+- Shared client models: goal and modal context may need to preserve `storyline_goal_id` and optional fellowship context so journal reads and writes validate correctly.
+- Testing and docs: new Jest, Vitest, and Playwright coverage plus updates to API, data-model, frontend, and architecture docs.

--- a/openspec/changes/goal-milestone-journals/specs/goal-journals/spec.md
+++ b/openspec/changes/goal-milestone-journals/specs/goal-journals/spec.md
@@ -1,0 +1,114 @@
+## ADDED Requirements
+
+### Requirement: Journal entries are unique per user and shared canonical goal
+The system SHALL store at most one journal entry per user for a canonical goal, and that same entry SHALL be used wherever the shared goal appears across storylines.
+
+#### Scenario: Shared goal shows the same journal across storylines
+- **WHEN** a user writes a journal entry for a canonical goal on one storyline
+- **THEN** opening the same canonical goal from another storyline shows the same journal entry instead of a separate storyline-specific entry
+
+#### Scenario: Reopening an existing shared-goal journal does not create a duplicate
+- **WHEN** a user revisits a canonical goal that already has their journal entry
+- **THEN** the system returns the existing entry for that user and goal rather than creating another journal record
+
+### Requirement: Goal-scoped journal state supports the milestone modal
+The system SHALL expose goal-scoped journal state for the authenticated viewer, including the viewer's own journal entry for that goal if present, the currently visible friend entries for that goal, and the permission state needed to render GoalModal.
+
+#### Scenario: Goal-scoped journal state returns own entry and permissions
+- **WHEN** an authenticated user requests journal state for a goal they can open in GoalModal
+- **THEN** the system returns the user's own journal entry for that goal if one exists and permission state indicating what journal actions are available
+
+#### Scenario: Fellowship context is reflected in goal-scoped journal state
+- **WHEN** an authenticated user requests journal state for a goal while viewing an eligible fellowship milestone context
+- **THEN** the returned permission state reflects that fellowship context for journal reads and writes
+
+#### Scenario: Empty journal state is returned without error
+- **WHEN** an authenticated user requests journal state for a goal that has no own entry and no visible friend entries
+- **THEN** the system returns an empty journal state rather than failing the milestone view
+
+### Requirement: Users can create, update, and delete their own goal journal entry
+The system SHALL allow an authenticated user to create or update their single journal entry for a goal and SHALL allow that same user to delete it later.
+
+#### Scenario: First save creates a journal entry
+- **WHEN** an authenticated user saves a valid journal entry for a goal that does not yet have their entry
+- **THEN** the system stores a new journal entry for that user and goal
+
+#### Scenario: Later save updates the existing journal entry
+- **WHEN** an authenticated user saves a valid journal entry for a goal that already has their entry
+- **THEN** the system updates the existing journal entry instead of creating another one
+
+#### Scenario: Author can delete their own journal entry
+- **WHEN** the author deletes their existing journal entry for a goal
+- **THEN** the system removes that user's journal entry for that goal
+
+### Requirement: Personal or fellowship reach grants journal write access
+The system SHALL allow a user to author or update their goal journal entry when they have personally reached the goal or when an active fellowship context they are viewing has reached that goal and they are an active member of that fellowship.
+
+#### Scenario: Personal progress grants write access
+- **WHEN** a user has personally reached a goal in their active storyline context
+- **THEN** the system allows that user to create or update their journal entry for the canonical goal
+
+#### Scenario: Fellowship progress grants individual write access
+- **WHEN** a user has not personally reached a goal but is actively viewing a fellowship context that has reached the same canonical goal and the user is an active member of that fellowship
+- **THEN** the system allows that user to create or update their own journal entry for that goal
+
+#### Scenario: Unreached personal and fellowship contexts deny write access
+- **WHEN** a user has not personally reached a goal and is not in an active fellowship context that has reached it
+- **THEN** the system denies journal creation or updates for that goal
+
+### Requirement: Friend journal visibility follows friendship and milestone visibility rules
+The system SHALL expose friend journal entries only from accepted friends and SHALL apply the viewer's milestone visibility preference to determine whether the viewer must also have reached the goal before reading them.
+
+#### Scenario: Accepted friend entry is visible when previews are enabled
+- **WHEN** the viewer and the author are accepted friends and the viewer has milestone previews enabled
+- **THEN** the system returns the friend's journal entry for that goal even if the viewer has not yet reached it
+
+#### Scenario: Accepted friend entry requires reach when previews are locked
+- **WHEN** the viewer and the author are accepted friends, the viewer has milestone previews locked, and the viewer has reached the goal in the current reading context
+- **THEN** the system returns the friend's journal entry for that goal
+
+#### Scenario: Locked previews hide friend entry until the viewer reaches the goal
+- **WHEN** the viewer and the author are accepted friends, the viewer has milestone previews locked, and the viewer has not reached the goal in the current reading context
+- **THEN** the system does not return that friend's journal entry for the goal
+
+#### Scenario: Non-friend entry is never visible
+- **WHEN** the journal author is not an accepted friend of the viewer
+- **THEN** the system does not return that journal entry in the viewer's friend journal list
+
+### Requirement: Journal bodies remain plain text and safe to render
+The system SHALL accept only non-empty plain-text journal bodies up to 2000 characters and SHALL render stored journal text without executing HTML or Markdown.
+
+#### Scenario: Empty journal body is rejected
+- **WHEN** a user submits a journal body that is empty after trimming
+- **THEN** the system rejects the save request
+
+#### Scenario: Overlength journal body is rejected
+- **WHEN** a user submits a journal body longer than 2000 characters
+- **THEN** the system rejects the save request
+
+#### Scenario: HTML-like journal text renders as text
+- **WHEN** a user stores journal text containing HTML-like or Markdown-like characters
+- **THEN** the journal body is displayed as plain text rather than executed or rendered as markup
+
+#### Scenario: Plain-text line breaks are preserved
+- **WHEN** a user stores journal text containing line breaks
+- **THEN** the journal body preserves those line breaks when displayed
+
+### Requirement: GoalModal presents milestone journals in MVP
+The system SHALL present journal authoring and visible friend journal reading inside GoalModal, using the goal-scoped journal state to choose between create, read, edit, delete, and hidden-section states.
+
+#### Scenario: GoalModal shows create state when no own entry exists
+- **WHEN** GoalModal opens for a goal and the viewer has no journal entry for that goal but has write access
+- **THEN** the modal shows journal authoring controls with a character counter and visibility selector
+
+#### Scenario: GoalModal shows read and edit state when own entry exists
+- **WHEN** GoalModal opens for a goal and the viewer already has a journal entry for that goal
+- **THEN** the modal shows the existing entry in read mode with actions to edit or delete it
+
+#### Scenario: GoalModal shows visible friend entries newest first
+- **WHEN** GoalModal opens for a goal and one or more friend journal entries are visible to the viewer
+- **THEN** the modal shows those friend entries ordered from newest to oldest
+
+#### Scenario: GoalModal hides the friends section when nothing is visible
+- **WHEN** GoalModal opens for a goal and no friend journal entries are visible under the viewer's current access rules
+- **THEN** the modal hides the friends journal section

--- a/openspec/changes/goal-milestone-journals/tasks.md
+++ b/openspec/changes/goal-milestone-journals/tasks.md
@@ -1,0 +1,33 @@
+## 1. Schema And Journal Data Access
+
+- [ ] 1.1 Add a D1 migration for `milestone_journals` with `(user_id, goal_id)` uniqueness, visibility validation, timestamps, and indexes for goal-scoped reads.
+- [ ] 1.2 Add strict TypeScript row types and shared data-access helpers for canonical goal journals, accepted-friend lookups, and storyline or fellowship reach checks.
+
+## 2. Worker Journal APIs And Access Rules
+
+- [ ] 2.1 Implement the goal-scoped journal-state read handler that returns own entry, visible friend entries, and permission flags for GoalModal.
+- [ ] 2.2 Implement the goal-scoped journal upsert handler with plain-text validation, personal reach checks, and fellowship-context write validation via optional `partyId`.
+- [ ] 2.3 Implement the goal-scoped journal delete handler for the current user's entry.
+- [ ] 2.4 Wire the new journal routes and allowed-method registration in `src/index.ts`.
+
+## 3. Modal Context Plumbing
+
+- [ ] 3.1 Extend shared goal and modal context types to preserve canonical `goal_id`, `storyline_goal_id`, and optional `partyId` where journal access rules need them.
+- [ ] 3.2 Update legacy and island-based GoalModal callers so personal, map, walk-congratulations, and fellowship milestone flows pass the correct journal context.
+
+## 4. GoalModal Journal Experience
+
+- [ ] 4.1 Update `GoalModal` to fetch goal-scoped journal state, show loading and error handling, and render own-entry plus friend-entry sections from permission flags.
+- [ ] 4.2 Add journal authoring, edit, and delete interactions with a 2000-character counter, visibility selector, and safe plain-text rendering with preserved line breaks.
+- [ ] 4.3 Hide the friends journal section when friend entries are not visible under the viewer's current friendship and preview rules.
+
+## 5. Validation Coverage
+
+- [ ] 5.1 Add Jest coverage for shared-goal identity across storylines, goal-scoped journal-state responses, personal and fellowship write access, friend visibility rules, plain-text validation, and route dispatch.
+- [ ] 5.2 Add Vitest coverage for GoalModal journal states in personal and fellowship contexts, including create, read, edit, delete, and hidden-friends states.
+- [ ] 5.3 Add Playwright coverage for personal journal authoring, fellowship-based journal authoring, and friend-entry visibility when milestone previews are enabled versus locked.
+
+## 6. Documentation And Change Hygiene
+
+- [ ] 6.1 Update the relevant docs in `docs/` for the new journal schema, goal-scoped API shape, GoalModal behavior, and the MVP exclusion of a standalone My Journal page.
+- [ ] 6.2 Verify the journal modal changes remain compatible with the adjacent goal-content change surfaces and document any merge-order considerations in the change notes if needed.


### PR DESCRIPTION
Introduce rich content management for goals, enabling admin CRUD and public API support. Add a global Field Guide for collectible flora and fauna with admin management and discovery mechanics. Implement milestone journal functionality, allowing users to leave reflections on shared goals with appropriate access and visibility rules.