### PR TITLE
feat: goal content (campfire lore)

### DIFF
--- a/client/src/islands/AdminGoalEditIsland.test.tsx
+++ b/client/src/islands/AdminGoalEditIsland.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, waitFor, fireEvent } from '@testing-library/preact';
+import { render, waitFor, fireEvent, screen } from '@testing-library/preact';
 import { AdminGoalEditIsland } from './AdminGoalEditIsland';
 
 const mockFetch = vi.fn();
@@ -47,7 +47,7 @@ afterEach(() => {
 });
 
 /** Wait for the initial goal load to complete (loading spinner disappears). */
-async function waitForGoalLoaded(container: HTMLElement) {
+async function waitForGoalLoaded(container: Element) {
   await waitFor(() => {
     expect(container.querySelector('.admin-loading')).toBeNull();
   });
@@ -74,6 +74,11 @@ describe('AdminGoalEditIsland', () => {
         ok: true,
         status: 200,
         json: () => Promise.resolve(mockGoalResponse),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ entries: [] }),
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -166,6 +171,11 @@ describe('AdminGoalEditIsland', () => {
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
+        json: () => Promise.resolve({ entries: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
         json: () => Promise.resolve({ ...mockGoalResponse, title: 'Updated Rivendell' }),
       });
 
@@ -193,6 +203,11 @@ describe('AdminGoalEditIsland', () => {
         ok: true,
         status: 200,
         json: () => Promise.resolve(mockGoalResponse),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ entries: [] }),
       })
       .mockResolvedValueOnce({
         ok: false,
@@ -258,5 +273,26 @@ describe('AdminGoalEditIsland', () => {
 
     const distInput = container.querySelector('#goal-distance') as HTMLInputElement;
     expect(distInput.step).toBe('any');
+  });
+
+  it('renders sanitized Markdown preview for goal content body', async () => {
+    const { container } = render(<AdminGoalEditIsland />);
+    await waitForGoalLoaded(container);
+
+    fireEvent.input(container.querySelector('#new-content-title') as HTMLInputElement, {
+      target: { value: 'Campfire tale' },
+    });
+    fireEvent.input(container.querySelector('#new-content-body') as HTMLTextAreaElement, {
+      target: { value: '**Bold** <img src=x onerror="alert(1)">' },
+    });
+
+    const previewButtons = screen.getAllByText('Preview');
+    fireEvent.click(previewButtons[previewButtons.length - 1]);
+
+    await waitFor(() => {
+      const preview = container.querySelector('.admin-goal-content__create .admin-goal-content-preview') as HTMLElement;
+      expect(preview.querySelector('strong')?.textContent).toBe('Bold');
+      expect(preview.innerHTML).not.toContain('onerror');
+    });
   });
 });

--- a/client/src/islands/AdminGoalEditIsland.tsx
+++ b/client/src/islands/AdminGoalEditIsland.tsx
@@ -24,7 +24,74 @@ interface FieldErrors {
   image_id?: string;
 }
 
+type GoalContentType = 'story' | 'poetry' | 'appendix';
+
+interface GoalContentEntry {
+  id: number;
+  goal_id: number;
+  type: GoalContentType;
+  title: string;
+  body: string;
+  author_attribution: string | null;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+}
+
+interface GoalContentFormState {
+  type: GoalContentType;
+  title: string;
+  body: string;
+  author_attribution: string;
+  sort_order: string;
+}
+
+interface GoalContentFieldErrors {
+  type?: string;
+  title?: string;
+  body?: string;
+  author_attribution?: string;
+  sort_order?: string;
+  form?: string;
+}
+
 const SLUG_REGEX = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+const GOAL_CONTENT_TYPES: GoalContentType[] = ['story', 'poetry', 'appendix'];
+const MAX_CONTENT_TITLE_LENGTH = 120;
+const MAX_CONTENT_ATTRIBUTION_LENGTH = 255;
+const MAX_CONTENT_BODY_LENGTH = 20000;
+const MAX_CONTENT_SORT_ORDER = 999;
+const EMPTY_CONTENT_FORM: GoalContentFormState = {
+  type: 'story',
+  title: '',
+  body: '',
+  author_attribution: '',
+  sort_order: '0',
+};
+
+/** Next default sort order: one above the highest existing entry (0 when empty). */
+function computeNextSortOrder(entries: GoalContentEntry[]): number {
+  if (entries.length === 0) return 0;
+  return Math.max(...entries.map((entry) => entry.sort_order)) + 1;
+}
+
+function sanitizeRenderedHtml(html: string): string {
+  const sanitized = DOMPurify.sanitize(html);
+  const template = document.createElement('template');
+  template.innerHTML = sanitized;
+  template.content.querySelectorAll('*').forEach((element) => {
+    Array.from(element.attributes).forEach((attr) => {
+      if (/^on/i.test(attr.name) || /^\s*javascript:/i.test(attr.value)) {
+        element.removeAttribute(attr.name);
+      }
+    });
+  });
+  return template.innerHTML;
+}
+
+function sanitizeMarkdown(markdown: string): string {
+  return sanitizeRenderedHtml(marked.parse(markdown) as string);
+}
 
 function getAuthHeaders(): Record<string, string> {
   const token = localStorage.getItem('sessionToken');
@@ -60,6 +127,21 @@ export function AdminGoalEditIsland() {
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Goal content authoring state
+  const [contentEntries, setContentEntries] = useState<GoalContentEntry[]>([]);
+  const [contentLoading, setContentLoading] = useState(false);
+  const [contentError, setContentError] = useState<string | null>(null);
+  const [contentForm, setContentForm] = useState<GoalContentFormState>({ ...EMPTY_CONTENT_FORM });
+  const [contentErrors, setContentErrors] = useState<GoalContentFieldErrors>({});
+  const [contentSaving, setContentSaving] = useState(false);
+  const [showContentPreview, setShowContentPreview] = useState(false);
+  const [editingContentId, setEditingContentId] = useState<number | null>(null);
+  const [editContentForm, setEditContentForm] = useState<GoalContentFormState>({ ...EMPTY_CONTENT_FORM });
+  const [editContentErrors, setEditContentErrors] = useState<GoalContentFieldErrors>({});
+  const [editContentSaving, setEditContentSaving] = useState(false);
+  const [showEditContentPreview, setShowEditContentPreview] = useState(false);
+  const [deletingContentId, setDeletingContentId] = useState<number | null>(null);
 
   // Image workflow state (Story 4.5)
   const [imageStatus, setImageStatus] = useState<'loading' | 'found' | 'missing' | 'none'>('none');
@@ -118,9 +200,42 @@ export function AdminGoalEditIsland() {
     }
   }, [goalId]);
 
+  const fetchContentEntries = useCallback(async () => {
+    if (!goalId) return;
+
+    setContentLoading(true);
+    setContentError(null);
+    try {
+      const res = await fetch(`/api/admin/goals/${goalId}/content`, {
+        headers: getAuthHeaders(),
+      });
+      if (res.status === 401) {
+        window.location.href = '/login';
+        return;
+      }
+      if (res.status === 403) {
+        window.location.href = '/journey';
+        return;
+      }
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(typeof data.error === 'string' ? data.error : 'Failed to load goal content');
+      }
+      const data: { entries?: GoalContentEntry[] } = await res.json();
+      const sortedEntries = [...(data.entries ?? [])].sort((a, b) => a.sort_order - b.sort_order);
+      setContentEntries(sortedEntries);
+      setContentForm((current) => ({ ...current, sort_order: String(computeNextSortOrder(sortedEntries)) }));
+    } catch (err) {
+      setContentError(err instanceof Error ? err.message : 'Failed to load goal content');
+    } finally {
+      setContentLoading(false);
+    }
+  }, [goalId]);
+
   useEffect(() => {
     fetchGoal();
-  }, [fetchGoal]);
+    fetchContentEntries();
+  }, [fetchGoal, fetchContentEntries]);
 
   // Clean up success timer on unmount
   useEffect(() => {
@@ -265,6 +380,159 @@ export function AdminGoalEditIsland() {
     }
   }, [goalId, title, distance, description, special, imageId, validate]);
 
+  const validateContentForm = useCallback((form: GoalContentFormState): GoalContentFieldErrors => {
+    const errs: GoalContentFieldErrors = {};
+    const titleValue = form.title.trim();
+    const bodyValue = form.body.trim();
+    const attributionValue = form.author_attribution.trim();
+    const sortOrderValue = Number(form.sort_order);
+
+    if (!GOAL_CONTENT_TYPES.includes(form.type)) {
+      errs.type = 'Content type is required';
+    }
+    if (!titleValue) {
+      errs.title = 'Title is required';
+    } else if (titleValue.length > MAX_CONTENT_TITLE_LENGTH) {
+      errs.title = `Title must be ${MAX_CONTENT_TITLE_LENGTH} characters or fewer`;
+    }
+    if (!bodyValue) {
+      errs.body = 'Body is required';
+    } else if (bodyValue.length > MAX_CONTENT_BODY_LENGTH) {
+      errs.body = `Body must be ${MAX_CONTENT_BODY_LENGTH} characters or fewer`;
+    }
+    if (attributionValue.length > MAX_CONTENT_ATTRIBUTION_LENGTH) {
+      errs.author_attribution = `Attribution must be ${MAX_CONTENT_ATTRIBUTION_LENGTH} characters or fewer`;
+    }
+    if (!form.sort_order.trim() || !Number.isInteger(sortOrderValue) || sortOrderValue < 0 || sortOrderValue > MAX_CONTENT_SORT_ORDER) {
+      errs.sort_order = `Sort order must be an integer from 0 to ${MAX_CONTENT_SORT_ORDER}`;
+    }
+
+    return errs;
+  }, []);
+
+  const buildContentPayload = useCallback((form: GoalContentFormState) => ({
+    type: form.type,
+    title: form.title.trim(),
+    body: form.body.trim(),
+    author_attribution: form.author_attribution.trim() || null,
+    sort_order: Number(form.sort_order),
+  }), []);
+
+  const parseContentError = useCallback(async (res: Response): Promise<string> => {
+    const data = await res.json().catch(() => ({}));
+    if (res.status === 409) {
+      return 'Sort order already exists for this goal. Choose a unique sort order.';
+    }
+    return typeof data.error === 'string' ? data.error : 'Failed to save goal content';
+  }, []);
+
+  const handleCreateContent = useCallback(async () => {
+    const validationErrors = validateContentForm(contentForm);
+    if (Object.keys(validationErrors).length > 0) {
+      setContentErrors(validationErrors);
+      return;
+    }
+
+    setContentErrors({});
+    setContentSaving(true);
+    setContentError(null);
+    try {
+      const res = await fetch(`/api/admin/goals/${goalId}/content`, {
+        method: 'POST',
+        headers: getAuthHeaders(),
+        body: JSON.stringify(buildContentPayload(contentForm)),
+      });
+      if (!res.ok) {
+        throw new Error(await parseContentError(res));
+      }
+      const created: GoalContentEntry = await res.json();
+      const updatedEntries = [...contentEntries, created].sort((a, b) => a.sort_order - b.sort_order);
+      setContentEntries(updatedEntries);
+      setContentForm({ ...EMPTY_CONTENT_FORM, sort_order: String(computeNextSortOrder(updatedEntries)) });
+      setShowContentPreview(false);
+      setSuccessMessage('Goal content created');
+    } catch (err) {
+      setContentErrors({ form: err instanceof Error ? err.message : 'Failed to create goal content' });
+    } finally {
+      setContentSaving(false);
+    }
+  }, [buildContentPayload, contentEntries, contentForm, goalId, parseContentError, validateContentForm]);
+
+  const startEditContent = useCallback((entry: GoalContentEntry) => {
+    setEditingContentId(entry.id);
+    setEditContentForm({
+      type: entry.type,
+      title: entry.title,
+      body: entry.body,
+      author_attribution: entry.author_attribution || '',
+      sort_order: String(entry.sort_order),
+    });
+    setEditContentErrors({});
+    setShowEditContentPreview(false);
+  }, []);
+
+  const cancelEditContent = useCallback(() => {
+    setEditingContentId(null);
+    setEditContentForm({ ...EMPTY_CONTENT_FORM });
+    setEditContentErrors({});
+    setShowEditContentPreview(false);
+  }, []);
+
+  const handleUpdateContent = useCallback(async (contentId: number) => {
+    const validationErrors = validateContentForm(editContentForm);
+    if (Object.keys(validationErrors).length > 0) {
+      setEditContentErrors(validationErrors);
+      return;
+    }
+
+    setEditContentErrors({});
+    setEditContentSaving(true);
+    try {
+      const res = await fetch(`/api/admin/goals/${goalId}/content/${contentId}`, {
+        method: 'PUT',
+        headers: getAuthHeaders(),
+        body: JSON.stringify(buildContentPayload(editContentForm)),
+      });
+      if (!res.ok) {
+        throw new Error(await parseContentError(res));
+      }
+      const updated: GoalContentEntry = await res.json();
+      setContentEntries((entries) => entries.map((entry) => entry.id === updated.id ? updated : entry).sort((a, b) => a.sort_order - b.sort_order));
+      setSuccessMessage('Goal content updated');
+      cancelEditContent();
+    } catch (err) {
+      setEditContentErrors({ form: err instanceof Error ? err.message : 'Failed to update goal content' });
+    } finally {
+      setEditContentSaving(false);
+    }
+  }, [buildContentPayload, cancelEditContent, editContentForm, goalId, parseContentError, validateContentForm]);
+
+  const handleDeleteContent = useCallback(async (contentId: number) => {
+    if (!confirm('Delete this goal content entry?')) return;
+
+    setDeletingContentId(contentId);
+    setContentError(null);
+    try {
+      const res = await fetch(`/api/admin/goals/${goalId}/content/${contentId}`, {
+        method: 'DELETE',
+        headers: getAuthHeaders(),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(typeof data.error === 'string' ? data.error : 'Failed to delete goal content');
+      }
+      setContentEntries((entries) => entries.filter((entry) => entry.id !== contentId));
+      setSuccessMessage('Goal content deleted');
+      if (editingContentId === contentId) {
+        cancelEditContent();
+      }
+    } catch (err) {
+      setContentError(err instanceof Error ? err.message : 'Failed to delete goal content');
+    } finally {
+      setDeletingContentId(null);
+    }
+  }, [cancelEditContent, editingContentId, goalId]);
+
   const hasValidationErrors = Object.keys(errors).length > 0;
 
   // Loading state
@@ -309,8 +577,248 @@ export function AdminGoalEditIsland() {
     );
   }
 
-  const previewHtml = showPreview ? DOMPurify.sanitize(marked.parse(description) as string) : '';
+  const previewHtml = showPreview ? sanitizeMarkdown(description) : '';
   const hasImage = !!(imageId.trim());
+  const contentPreviewHtml = showContentPreview ? sanitizeMarkdown(contentForm.body) : '';
+  const editContentPreviewHtml = showEditContentPreview ? sanitizeMarkdown(editContentForm.body) : '';
+
+  const renderContentFields = (
+    form: GoalContentFormState,
+    setForm: (updater: (current: GoalContentFormState) => GoalContentFormState) => void,
+    formErrors: GoalContentFieldErrors,
+    previewEnabled: boolean,
+    setPreviewEnabled: (enabled: boolean) => void,
+    previewBodyHtml: string,
+    prefix: string,
+  ) => (
+    <>
+      <div className="admin-goal-field">
+        <label htmlFor={`${prefix}-type`}>
+          Type <span className="admin-goal-required" aria-hidden="true">*</span>
+        </label>
+        <select
+          id={`${prefix}-type`}
+          value={form.type}
+          onInput={(e) => setForm((current) => ({ ...current, type: (e.target as HTMLSelectElement).value as GoalContentType }))}
+          aria-invalid={!!formErrors.type}
+        >
+          <option value="story">Story</option>
+          <option value="poetry">Poetry</option>
+          <option value="appendix">Appendix</option>
+        </select>
+        {formErrors.type && <span className="field-error" role="alert">{formErrors.type}</span>}
+      </div>
+
+      <div className="admin-goal-field">
+        <label htmlFor={`${prefix}-title`}>
+          Title <span className="admin-goal-required" aria-hidden="true">*</span>
+        </label>
+        <input
+          id={`${prefix}-title`}
+          type="text"
+          maxLength={MAX_CONTENT_TITLE_LENGTH}
+          value={form.title}
+          onInput={(e) => setForm((current) => ({ ...current, title: (e.target as HTMLInputElement).value }))}
+          aria-invalid={!!formErrors.title}
+        />
+        <small className="admin-goal-field__hint">{form.title.length}/{MAX_CONTENT_TITLE_LENGTH}</small>
+        {formErrors.title && <span className="field-error" role="alert">{formErrors.title}</span>}
+      </div>
+
+      <div className="admin-goal-field">
+        <label htmlFor={`${prefix}-sort-order`}>
+          Sort order <span className="admin-goal-required" aria-hidden="true">*</span>
+        </label>
+        <input
+          id={`${prefix}-sort-order`}
+          type="number"
+          min="0"
+          max={MAX_CONTENT_SORT_ORDER}
+          step="1"
+          value={form.sort_order}
+          onInput={(e) => setForm((current) => ({ ...current, sort_order: (e.target as HTMLInputElement).value }))}
+          aria-invalid={!!formErrors.sort_order}
+        />
+        <small className="admin-goal-field__hint">
+          Controls display order — lower numbers appear first. Each entry needs a unique number.
+        </small>
+        {formErrors.sort_order && <span className="field-error" role="alert">{formErrors.sort_order}</span>}
+      </div>
+
+      <div className="admin-goal-field">
+        <label htmlFor={`${prefix}-attribution`}>Attribution</label>
+        <input
+          id={`${prefix}-attribution`}
+          type="text"
+          maxLength={MAX_CONTENT_ATTRIBUTION_LENGTH}
+          value={form.author_attribution}
+          onInput={(e) => setForm((current) => ({ ...current, author_attribution: (e.target as HTMLInputElement).value }))}
+          aria-invalid={!!formErrors.author_attribution}
+        />
+        <small className="admin-goal-field__hint">{form.author_attribution.length}/{MAX_CONTENT_ATTRIBUTION_LENGTH}</small>
+        {formErrors.author_attribution && <span className="field-error" role="alert">{formErrors.author_attribution}</span>}
+      </div>
+
+      <div className="admin-goal-field">
+        <label htmlFor={`${prefix}-body`}>
+          Markdown body <span className="admin-goal-required" aria-hidden="true">*</span>
+        </label>
+        <div className="admin-goal-preview-toggle">
+          <button
+            type="button"
+            className={`admin-goal-preview-toggle__btn ${!previewEnabled ? 'admin-goal-preview-toggle__btn--active' : ''}`}
+            onClick={() => setPreviewEnabled(false)}
+          >
+            Edit
+          </button>
+          <button
+            type="button"
+            className={`admin-goal-preview-toggle__btn ${previewEnabled ? 'admin-goal-preview-toggle__btn--active' : ''}`}
+            onClick={() => setPreviewEnabled(true)}
+          >
+            Preview
+          </button>
+        </div>
+        {!previewEnabled ? (
+          <textarea
+            id={`${prefix}-body`}
+            rows={8}
+            maxLength={MAX_CONTENT_BODY_LENGTH}
+            value={form.body}
+            onInput={(e) => setForm((current) => ({ ...current, body: (e.target as HTMLTextAreaElement).value }))}
+            aria-invalid={!!formErrors.body}
+          />
+        ) : (
+          <div
+            className="admin-goal-preview admin-goal-content-preview"
+            dangerouslySetInnerHTML={{ __html: previewBodyHtml }}
+          />
+        )}
+        <small className="admin-goal-field__hint">{form.body.length}/{MAX_CONTENT_BODY_LENGTH}</small>
+        {formErrors.body && <span className="field-error" role="alert">{formErrors.body}</span>}
+      </div>
+
+      {formErrors.form && (
+        <div className="admin-error" role="alert">
+          {formErrors.form}
+        </div>
+      )}
+    </>
+  );
+
+  const renderGoalContentManagement = () => (
+    <section className="admin-goal-content" style={{ marginTop: '2em' }}>
+      <h3>Goal Content</h3>
+      <p className="admin-goal-field__hint">
+        Add ordered campfire stories, poems, and appendices. Reorder by editing sort order directly.
+      </p>
+
+      {contentError && (
+        <div className="admin-error" role="alert">
+          {contentError}
+          <button type="button" className="admin-error__btn" onClick={fetchContentEntries} style={{ marginLeft: '0.75em' }}>
+            Retry
+          </button>
+        </div>
+      )}
+
+      <div className="admin-goal-content__list" style={{ margin: '1em 0' }}>
+        {contentLoading ? (
+          <div className="admin-loading">
+            <i className="fas fa-spinner fa-spin" aria-hidden="true"></i> Loading goal content...
+          </div>
+        ) : contentEntries.length === 0 ? (
+          <div className="admin-empty-state">No goal content yet.</div>
+        ) : (
+          contentEntries.map((entry) => (
+            <article key={entry.id} className="admin-goal-content__entry" style={{ border: '1px solid #444', borderRadius: '8px', padding: '1em', marginBottom: '1em' }}>
+              {editingContentId === entry.id ? (
+                <form
+                  onSubmit={(e) => {
+                    e.preventDefault();
+                    handleUpdateContent(entry.id);
+                  }}
+                >
+                  {renderContentFields(
+                    editContentForm,
+                    setEditContentForm,
+                    editContentErrors,
+                    showEditContentPreview,
+                    setShowEditContentPreview,
+                    editContentPreviewHtml,
+                    `edit-content-${entry.id}`,
+                  )}
+                  <div className="admin-goal-actions" style={{ marginTop: '0.75em' }}>
+                    <button type="submit" className="admin-goal-actions__save" disabled={editContentSaving}>
+                      {editContentSaving ? 'Saving...' : 'Save Content'}
+                    </button>
+                    <button type="button" className="admin-goal-actions__back" onClick={cancelEditContent}>
+                      Cancel
+                    </button>
+                  </div>
+                </form>
+              ) : (
+                <>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1em', flexWrap: 'wrap' }}>
+                    <div>
+                      <span className={`goal-content-badge goal-content-badge--${entry.type}`}>{entry.type}</span>
+                      <h4 style={{ margin: '0.25em 0' }}>{entry.title}</h4>
+                      <div className="admin-goal-field__hint">Sort order: {entry.sort_order}</div>
+                      {entry.author_attribution && (
+                        <div className="admin-goal-field__hint">Attribution: {entry.author_attribution}</div>
+                      )}
+                    </div>
+                    <div style={{ display: 'flex', gap: '0.5em', alignItems: 'flex-start' }}>
+                      <button type="button" className="admin-image-section__browse-btn" onClick={() => startEditContent(entry)}>
+                        Edit
+                      </button>
+                      <button
+                        type="button"
+                        className="admin-image-section__browse-btn"
+                        onClick={() => handleDeleteContent(entry.id)}
+                        disabled={deletingContentId === entry.id}
+                      >
+                        {deletingContentId === entry.id ? 'Deleting...' : 'Delete'}
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    className="admin-goal-preview admin-goal-content-preview"
+                    style={{ marginTop: '0.75em' }}
+                    dangerouslySetInnerHTML={{ __html: sanitizeMarkdown(entry.body) }}
+                  />
+                </>
+              )}
+            </article>
+          ))
+        )}
+      </div>
+
+      <form
+        className="admin-goal-form admin-goal-content__create"
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleCreateContent();
+        }}
+      >
+        <h4>Add Content Entry</h4>
+        {renderContentFields(
+          contentForm,
+          setContentForm,
+          contentErrors,
+          showContentPreview,
+          setShowContentPreview,
+          contentPreviewHtml,
+          'new-content',
+        )}
+        <div className="admin-goal-actions">
+          <button type="submit" className="admin-goal-actions__save" disabled={contentSaving}>
+            {contentSaving ? 'Creating...' : 'Create Content'}
+          </button>
+        </div>
+      </form>
+    </section>
+  );
 
   return (
     <div className="admin-goal-edit">
@@ -581,11 +1089,16 @@ export function AdminGoalEditIsland() {
               </>
             )}
           </button>
-          <a href="/admin/goals" className="admin-goal-actions__back">
-            <i className="fas fa-arrow-left" aria-hidden="true"></i> Back to Goals
-          </a>
         </div>
       </form>
+
+      {renderGoalContentManagement()}
+
+      <div className="admin-goal-actions" style={{ marginTop: '1.5em' }}>
+        <a href="/admin/goals" className="admin-goal-actions__back">
+          <i className="fas fa-arrow-left" aria-hidden="true"></i> Back to Goals
+        </a>
+      </div>
 
       {/* Image Browser Modal (Story 4.5 — AC5) */}
       <ImageBrowserModal

--- a/client/src/islands/GoalModal.test.tsx
+++ b/client/src/islands/GoalModal.test.tsx
@@ -412,6 +412,178 @@ describe('GoalModal', () => {
   });
 });
 
+// ── Goal Content Tests ──────────────────────────────────────────────────────
+
+describe('GoalModal content', () => {
+  const mockGoal = {
+    id: 7,
+    distance: 100.5,
+    title: 'Lore Goal',
+    special: null,
+    description: 'A lore-rich goal',
+    image_id: '1',
+    has_content: true,
+  };
+
+  const mockOnClose = vi.fn();
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  const journalPayload = {
+    ownEntry: null,
+    friendEntries: [],
+    permissions: {
+      canWrite: false,
+      canEditOwn: false,
+      canDeleteOwn: false,
+      canReadFriends: false,
+    },
+  };
+
+  beforeEach(() => {
+    mockOnClose.mockClear();
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  function mockContentResponses(entries: Array<Record<string, unknown>>) {
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/content/events')) {
+        return Promise.resolve({ ok: true, status: 202, json: () => Promise.resolve({}) });
+      }
+      if (url.includes('/content')) {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ entries }) });
+      }
+      if (url.includes('/journals')) {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(journalPayload) });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({}) });
+    });
+  }
+
+  it('renders unlocked content entries by type in sort order', async () => {
+    mockContentResponses([
+      {
+        id: 3,
+        goal_id: 7,
+        type: 'appendix',
+        title: 'Appendix Note',
+        body: 'Reference **facts**.',
+        author_attribution: 'Archivist',
+        sort_order: 3,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+      {
+        id: 1,
+        goal_id: 7,
+        type: 'story',
+        title: 'Campfire Tale',
+        body: 'A **warm** story.',
+        author_attribution: null,
+        sort_order: 1,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+      {
+        id: 2,
+        goal_id: 7,
+        type: 'poetry',
+        title: 'Walking Song',
+        body: 'Line one\n\nLine two',
+        author_attribution: null,
+        sort_order: 2,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+    ]);
+
+    const { container } = render(
+      <GoalModal
+        goal={mockGoal}
+        currentDistance={150}
+        onClose={mockOnClose}
+      />
+    );
+
+    // Panel renders collapsed by default with a summary of counts.
+    await waitFor(() => {
+      expect(screen.getByText('Campfire Lore')).toBeTruthy();
+      expect(screen.getByText('1 story')).toBeTruthy();
+      expect(screen.getByText('1 poem')).toBeTruthy();
+      expect(screen.getByText('1 appendix')).toBeTruthy();
+    });
+    expect(screen.queryByText('Campfire Tale')).toBeNull();
+
+    // Expand to reveal entries.
+    (container.querySelector('.goal-content-toggle') as HTMLButtonElement).click();
+
+    await waitFor(() => {
+      expect(screen.getByText('Campfire Tale')).toBeTruthy();
+      expect(screen.getByText('Walking Song')).toBeTruthy();
+      expect(screen.getByText('Appendix Note')).toBeTruthy();
+    });
+
+    const titles = Array.from(container.querySelectorAll('.goal-content-entry h4')).map((el) => el.textContent);
+    expect(titles).toEqual(['Campfire Tale', 'Walking Song', 'Appendix Note']);
+    expect(screen.getByText('Campfire Story')).toBeTruthy();
+    expect(screen.getByText('Poetry')).toBeTruthy();
+    expect(screen.getByText('Appendix')).toBeTruthy();
+    expect(container.querySelector('.goal-content-entry--story strong')?.textContent).toBe('warm');
+    expect(screen.getByText(/Archivist/)).toBeTruthy();
+  });
+
+  it('collapses and expands appendices over 500 rendered words', async () => {
+    const longBody = Array.from({ length: 501 }, (_, index) => `word${index + 1}`).join(' ');
+    mockContentResponses([
+      {
+        id: 9,
+        goal_id: 7,
+        type: 'appendix',
+        title: 'Long Appendix',
+        body: longBody,
+        author_attribution: null,
+        sort_order: 1,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+    ]);
+
+    const { container } = render(
+      <GoalModal
+        goal={mockGoal}
+        currentDistance={150}
+        onClose={mockOnClose}
+      />
+    );
+
+    // Expand the collapsed lore panel first.
+    await waitFor(() => {
+      expect(screen.getByText('Campfire Lore')).toBeTruthy();
+    });
+    (container.querySelector('.goal-content-toggle') as HTMLButtonElement).click();
+
+    await waitFor(() => {
+      expect(screen.getByText('Long Appendix')).toBeTruthy();
+      expect(screen.getByText('Expand appendix')).toBeTruthy();
+    });
+
+    expect(screen.queryByText((content) => content.includes('word501'))).toBeNull();
+
+    screen.getByText('Expand appendix').click();
+
+    await waitFor(() => {
+      expect(screen.getByText((content) => content.includes('word501'))).toBeTruthy();
+      expect(screen.getByText('Collapse appendix')).toBeTruthy();
+    });
+  });
+});
+
 // ── Journal Tests ──────────────────────────────────────────────────────────
 
 describe('GoalModal Journal', () => {
@@ -430,11 +602,12 @@ describe('GoalModal Journal', () => {
   beforeEach(() => {
     mockOnClose.mockClear();
     fetchMock = vi.fn();
-    globalThis.fetch = fetchMock;
+    vi.stubGlobal('fetch', fetchMock);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   function mockJournalResponse(data: Record<string, unknown>, status = 200) {

--- a/client/src/islands/GoalModal.tsx
+++ b/client/src/islands/GoalModal.tsx
@@ -1,7 +1,14 @@
 import { useSignal, useComputed } from '@preact/signals';
-import { useEffect, useRef } from 'preact/hooks';
+import { useEffect, useRef, useState } from 'preact/hooks';
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
 import type { Goal } from '../types/goal';
 import { getAuthHeaders } from '../utils/auth';
+import { recordGoalContentEvent } from '../utils/goalContentEvents';
+
+marked.setOptions({
+  breaks: true,
+});
 
 // ── Journal Types ──────────────────────────────────────────────────────────
 
@@ -36,10 +43,72 @@ interface GoalJournalState {
 
 type JournalLoadState = 'idle' | 'loading' | 'ready' | 'error';
 type JournalMode = 'create' | 'view' | 'edit';
+type GoalContentType = 'story' | 'poetry' | 'appendix';
+type GoalContentLoadState = 'idle' | 'loading' | 'ready' | 'error';
+
+interface GoalContentEntry {
+  id: number;
+  goal_id: number;
+  type: GoalContentType;
+  title: string;
+  body: string;
+  author_attribution: string | null;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+}
 
 // ── Constants ──────────────────────────────────────────────────────────────
 
 const MAX_BODY_LENGTH = 2000;
+const APPENDIX_COLLAPSE_WORDS = 500;
+
+function sanitizeRenderedHtml(html: string): string {
+  const sanitized = DOMPurify.sanitize(html);
+  const template = document.createElement('template');
+  template.innerHTML = sanitized;
+  template.content.querySelectorAll('*').forEach((element) => {
+    Array.from(element.attributes).forEach((attr) => {
+      if (/^on/i.test(attr.name) || /^\s*javascript:/i.test(attr.value)) {
+        element.removeAttribute(attr.name);
+      }
+    });
+  });
+  return template.innerHTML;
+}
+
+function renderMarkdown(body: string): string {
+  return sanitizeRenderedHtml(marked.parse(body) as string);
+}
+
+function getPlainTextFromHtml(html: string): string {
+  const template = document.createElement('template');
+  template.innerHTML = html;
+  return template.content.textContent || '';
+}
+
+function getWords(text: string): string[] {
+  return text.trim().split(/\s+/).filter(Boolean);
+}
+
+function getContentTypeLabel(type: GoalContentType): string {
+  if (type === 'story') return 'Campfire Story';
+  if (type === 'poetry') return 'Poetry';
+  return 'Appendix';
+}
+
+/** Human summary of lore entries by type, e.g. ["2 stories", "1 poem"]. */
+function formatLoreSummary(entries: GoalContentEntry[]): string[] {
+  const counts: Record<GoalContentType, number> = { story: 0, poetry: 0, appendix: 0 };
+  for (const entry of entries) {
+    counts[entry.type] += 1;
+  }
+  const parts: string[] = [];
+  if (counts.story) parts.push(`${counts.story} ${counts.story === 1 ? 'story' : 'stories'}`);
+  if (counts.poetry) parts.push(`${counts.poetry} ${counts.poetry === 1 ? 'poem' : 'poems'}`);
+  if (counts.appendix) parts.push(`${counts.appendix} ${counts.appendix === 1 ? 'appendix' : 'appendices'}`);
+  return parts;
+}
 
 // ── Component ──────────────────────────────────────────────────────────────
 
@@ -59,6 +128,7 @@ export function GoalModal({ goal, currentDistance, isCongratulations = false, lo
   const highResLoaded = useSignal(false);
   const thumbFormat = useSignal<'webp' | 'jpg'>('webp');
   const highResFormat = useSignal<'webp' | 'jpg'>('webp');
+  const [expandedAppendices, setExpandedAppendices] = useState<ReadonlySet<number>>(() => new Set());
 
   // ── Journal State ──
   const journalState = useSignal<GoalJournalState | null>(null);
@@ -69,10 +139,64 @@ export function GoalModal({ goal, currentDistance, isCongratulations = false, lo
   const journalError = useSignal<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
+  // ── Goal Content State ──
+  const contentEntries = useSignal<GoalContentEntry[]>([]);
+  const contentLoadState = useSignal<GoalContentLoadState>('idle');
+  const contentError = useSignal<string | null>(null);
+  const contentOpenSentForGoal = useRef<number | null>(null);
+  const loreExpanded = useSignal(false);
+
   // ── Computed ──
   const isCompleted = Number(currentDistance) >= goal.distance;
   const distanceToGo = isCompleted ? 0 : goal.distance - Number(currentDistance);
   const charCount = useComputed(() => journalText.value.length);
+
+  // ── Goal Content Fetch ──
+  const fetchGoalContent = async () => {
+    contentLoadState.value = 'loading';
+    contentError.value = null;
+    try {
+      let url = `/api/goals/${goal.id}/content`;
+      if (partyId) {
+        url += `?partyId=${partyId}`;
+      }
+      const resp = await fetch(url, { headers: getAuthHeaders() });
+      if (!resp.ok) {
+        throw new Error(`Failed to load goal content (${resp.status})`);
+      }
+      const data: { entries?: GoalContentEntry[] } = await resp.json();
+      const entries = [...(data.entries ?? [])].sort((a, b) => a.sort_order - b.sort_order);
+      contentEntries.value = entries;
+      contentLoadState.value = 'ready';
+
+      if (entries.length > 0 && contentOpenSentForGoal.current !== goal.id) {
+        contentOpenSentForGoal.current = goal.id;
+        recordGoalContentEvent({
+          goalId: goal.id,
+          eventType: 'content_open',
+          partyId,
+          contentId: entries[0].id,
+        });
+      }
+    } catch (err) {
+      contentEntries.value = [];
+      contentLoadState.value = 'error';
+      contentError.value = err instanceof Error ? err.message : 'Failed to load goal content';
+    }
+  };
+
+  useEffect(() => {
+    contentEntries.value = [];
+    contentError.value = null;
+    contentLoadState.value = 'idle';
+    contentOpenSentForGoal.current = null;
+    loreExpanded.value = false;
+    setExpandedAppendices(new Set());
+
+    if (!locked && goal.has_content === true) {
+      fetchGoalContent();
+    }
+  }, [goal.id, goal.has_content, locked, partyId]);
 
   // ── Journal Fetch ──
   const fetchJournalState = async () => {
@@ -287,6 +411,148 @@ export function GoalModal({ goal, currentDistance, isCongratulations = false, lo
     ? 'text-decoration: line-through; color: #888;'
     : 'color: #FFD700;';
 
+  const toggleAppendix = (entryId: number) => {
+    setExpandedAppendices((current) => {
+      const next = new Set(current);
+      if (next.has(entryId)) {
+        next.delete(entryId);
+      } else {
+        next.add(entryId);
+      }
+      return next;
+    });
+  };
+
+  const renderContentEntry = (entry: GoalContentEntry) => {
+    const html = renderMarkdown(entry.body);
+    const plainText = getPlainTextFromHtml(html);
+    const words = getWords(plainText);
+    const isLongAppendix = entry.type === 'appendix' && words.length > APPENDIX_COLLAPSE_WORDS;
+    const isExpanded = expandedAppendices.has(entry.id);
+    const typeLabel = getContentTypeLabel(entry.type);
+    const bodyClass = `goal-content-entry__body goal-content-entry__body--${entry.type}`;
+    const bodyStyle = entry.type === 'poetry'
+      ? 'color: #ddd; line-height: 1.7; text-align: center; white-space: pre-wrap;'
+      : 'color: #ccc; line-height: 1.55;';
+    const entryStyle = entry.type === 'story'
+      ? 'background: linear-gradient(135deg, rgba(70, 43, 18, 0.38), rgba(24, 20, 16, 0.96)); border-color: rgba(255, 166, 77, 0.35);'
+      : entry.type === 'poetry'
+        ? 'background: rgba(36, 32, 52, 0.7); border-color: rgba(180, 160, 255, 0.35);'
+        : 'background: rgba(26, 34, 36, 0.82); border-color: rgba(120, 190, 170, 0.35);';
+
+    return (
+      <article
+        key={entry.id}
+        class={`goal-content-entry goal-content-entry--${entry.type}`}
+        style={`margin-top: 0.9em; padding: 1em; border: 1px solid; border-radius: 10px; ${entryStyle}`}
+      >
+        <div style="display: flex; align-items: center; gap: 0.6em; flex-wrap: wrap; margin-bottom: 0.55em;">
+          <span
+            class={`goal-content-badge goal-content-badge--${entry.type}`}
+            style="font-size: 0.72em; letter-spacing: 0.06em; text-transform: uppercase; color: #111; background: #FFD700; border-radius: 999px; padding: 0.2em 0.55em; font-weight: 700;"
+          >
+            {typeLabel}
+          </span>
+          <h4 style="margin: 0; color: #fff; font-size: 1.05em;">{entry.title}</h4>
+        </div>
+
+        {isLongAppendix && !isExpanded ? (
+          <div class={bodyClass} style={bodyStyle}>
+            <p>{words.slice(0, APPENDIX_COLLAPSE_WORDS).join(' ')}…</p>
+          </div>
+        ) : (
+          <div
+            class={bodyClass}
+            style={bodyStyle}
+            dangerouslySetInnerHTML={{ __html: html }}
+          />
+        )}
+
+        {entry.author_attribution && (
+          <div class="goal-content-entry__attribution" style="margin-top: 0.7em; color: #999; font-size: 0.85em; font-style: italic;">
+            — {entry.author_attribution}
+          </div>
+        )}
+
+        {isLongAppendix && (
+          <button
+            type="button"
+            class="btn btn-secondary btn-sm"
+            onClick={() => toggleAppendix(entry.id)}
+            aria-expanded={isExpanded}
+            style="margin-top: 0.8em; font-size: 0.82em;"
+          >
+            {isExpanded ? 'Collapse appendix' : 'Expand appendix'}
+          </button>
+        )}
+      </article>
+    );
+  };
+
+  const renderGoalContentSection = () => {
+    if (locked || goal.has_content !== true) {
+      return null;
+    }
+
+    if (contentLoadState.value === 'idle' || contentLoadState.value === 'loading') {
+      return (
+        <section class="goal-content-section" aria-label="Goal content" style="margin: 1em 0;">
+          <div style="color: #888; text-align: center; padding: 0.8em; border: 1px solid #333; border-radius: 8px;">
+            <i class="fas fa-spinner fa-pulse" aria-hidden="true" style="margin-right: 0.4em;" />
+            Loading campfire lore...
+          </div>
+        </section>
+      );
+    }
+
+    if (contentLoadState.value === 'error') {
+      return (
+        <section class="goal-content-section" aria-label="Goal content" style="margin: 1em 0;">
+          <div style="color: #c44; text-align: center; padding: 0.8em; border: 1px solid #5a2424; border-radius: 8px;">
+            {contentError.value || 'Failed to load goal content'}
+          </div>
+        </section>
+      );
+    }
+
+    if (contentEntries.value.length === 0) {
+      return null;
+    }
+
+    const summary = formatLoreSummary(contentEntries.value);
+    const expanded = loreExpanded.value;
+
+    return (
+      <section class="goal-content-section" aria-label="Campfire lore" style="margin: 1em 0;">
+        <button
+          type="button"
+          class="goal-content-toggle"
+          aria-expanded={expanded}
+          onClick={() => { loreExpanded.value = !loreExpanded.value; }}
+          style="width: 100%; display: flex; align-items: center; gap: 0.5em; background: rgba(255, 215, 0, 0.08); border: 1px solid rgba(255, 166, 77, 0.35); border-radius: 8px; padding: 0.6em 0.8em; color: #FFD700; font-size: 1.05em; cursor: pointer; text-align: left;"
+        >
+          <span aria-hidden="true">🔥</span>
+          <span style="font-weight: 600;">Campfire Lore</span>
+          {summary.length > 0 && (
+            <span style="display: flex; flex-direction: column; color: #d8c06a; font-size: 0.82em; font-weight: 400; line-height: 1.4;">
+              {summary.map(part => <span>{part}</span>)}
+            </span>
+          )}
+          <i
+            class={`fas fa-chevron-${expanded ? 'up' : 'down'}`}
+            aria-hidden="true"
+            style="margin-left: auto; font-size: 0.8em;"
+          />
+        </button>
+        {expanded && (
+          <div style="margin-top: 0.6em;">
+            {contentEntries.value.map(renderContentEntry)}
+          </div>
+        )}
+      </section>
+    );
+  };
+
   // ═══════════════════════════════════════════════════════════════════════════
   // RENDER: Goal Details (image + description + Journals button)
   // ═══════════════════════════════════════════════════════════════════════════
@@ -328,6 +594,8 @@ export function GoalModal({ goal, currentDistance, isCongratulations = false, lo
           {goal.description}
         </div>
       )}
+
+      {renderGoalContentSection()}
 
       {/* Journals button — full width, styled, only when not locked */}
       {!locked && (

--- a/client/src/islands/NextGoalCard.test.tsx
+++ b/client/src/islands/NextGoalCard.test.tsx
@@ -88,7 +88,7 @@ describe('NextGoalCard', () => {
       />
     );
 
-    const card = container.querySelector('.upcoming-goal.next-goal');
+    const card = container.querySelector('.upcoming-goal.next-goal') as HTMLElement | null;
     expect(card).toBeTruthy();
   });
 
@@ -103,7 +103,7 @@ describe('NextGoalCard', () => {
       />
     );
 
-    const card = container.querySelector('.upcoming-goal.next-goal');
+    const card = container.querySelector('.upcoming-goal.next-goal') as HTMLElement | null;
     card?.click();
     
     expect(handleClick).toHaveBeenCalledTimes(1);
@@ -202,7 +202,7 @@ describe('NextGoalCard', () => {
       />
     );
 
-    const card = container.querySelector('.upcoming-goal.next-goal');
+    const card = container.querySelector('.upcoming-goal.next-goal') as HTMLElement | null;
     card?.click();
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
@@ -219,5 +219,35 @@ describe('NextGoalCard', () => {
 
     const lockIcon = container.querySelector('.fas.fa-lock');
     expect(lockIcon).toBeNull();
+  });
+
+  it('locked goal with has_content=true shows lore teaser', () => {
+    const { container } = render(
+      <NextGoalCard
+        goal={{ ...mockGoal, has_content: true }}
+        currentDistance={75}
+        previousDistance={50}
+        locked={true}
+        onClick={() => {}}
+      />
+    );
+
+    expect(container.textContent).toContain('Campfire lore waits beyond this milestone');
+    expect(container.querySelector('.goal-content-teaser')).toBeTruthy();
+  });
+
+  it('locked goal without content does not show lore teaser', () => {
+    const { container } = render(
+      <NextGoalCard
+        goal={{ ...mockGoal, has_content: false }}
+        currentDistance={75}
+        previousDistance={50}
+        locked={true}
+        onClick={() => {}}
+      />
+    );
+
+    expect(container.textContent).not.toContain('Campfire lore waits beyond this milestone');
+    expect(container.querySelector('.goal-content-teaser')).toBeNull();
   });
 });

--- a/client/src/islands/NextGoalCard.tsx
+++ b/client/src/islands/NextGoalCard.tsx
@@ -1,4 +1,6 @@
 import type { Goal } from '../types/goal';
+import { useEffect } from 'preact/hooks';
+import { recordGoalContentEvent } from '../utils/goalContentEvents';
 
 interface NextGoalCardProps {
   goal: Goal;
@@ -6,19 +8,27 @@ interface NextGoalCardProps {
   previousDistance: number;
   locked?: boolean;
   onClick?: () => void;
+  partyId?: number | null;
 }
 
 /**
  * NextGoalCard - Preact Island for the next goal with progress bar
  * Displays the immediate next goal with visual emphasis and segment progress
  */
-export function NextGoalCard({ goal, currentDistance, previousDistance, locked = false, onClick }: NextGoalCardProps) {
+export function NextGoalCard({ goal, currentDistance, previousDistance, locked = false, onClick, partyId = null }: NextGoalCardProps) {
   // Calculate segment progress
   const segmentTotal = goal.distance - previousDistance;
   const segmentProgress = currentDistance - previousDistance;
   const percentage = Math.max(0, Math.min(100, (segmentProgress / segmentTotal) * 100));
   const hasVisibleProgress = percentage > 0;
   const distanceToGo = goal.distance - currentDistance;
+  const showContentTeaser = locked && goal.has_content === true;
+
+  useEffect(() => {
+    if (showContentTeaser) {
+      recordGoalContentEvent({ goalId: goal.id, eventType: 'teaser_impression', partyId });
+    }
+  }, [showContentTeaser, goal.id, partyId]);
 
   return (
     <div 
@@ -71,7 +81,31 @@ export function NextGoalCard({ goal, currentDistance, previousDistance, locked =
           ({distanceToGo.toFixed(2)} km to go)
         </span>
       </span>
-      
+
+      {showContentTeaser && (
+        <div
+          className="goal-content-teaser"
+          aria-label="Locked campfire lore available"
+          style={{
+            marginTop: '0.7em',
+            width: '100%',
+            padding: '0.55em 0.7em',
+            border: '1px solid rgba(255, 215, 0, 0.35)',
+            borderRadius: '8px',
+            background: 'rgba(255, 215, 0, 0.08)',
+            color: '#d8c06a',
+            fontSize: '0.85em',
+            textAlign: 'center',
+            boxSizing: 'border-box',
+          }}
+        >
+          🔥 Campfire lore waits beyond this milestone
+          <div style={{ marginTop: '0.25em', filter: 'blur(3px)', color: '#aaa', userSelect: 'none' }} aria-hidden="true">
+            Ancient words and hidden tales...
+          </div>
+        </div>
+      )}
+       
       {/* Progress Bar */}
       <div 
         className="goal-progress-track"

--- a/client/src/islands/UpcomingGoalCard.test.tsx
+++ b/client/src/islands/UpcomingGoalCard.test.tsx
@@ -66,7 +66,7 @@ describe('UpcomingGoalCard', () => {
       />
     );
 
-    const card = container.querySelector('.upcoming-goal');
+    const card = container.querySelector('.upcoming-goal') as HTMLElement | null;
     expect(card).toBeTruthy();
   });
 
@@ -109,7 +109,7 @@ describe('UpcomingGoalCard', () => {
       />
     );
 
-    const card = container.querySelector('.upcoming-goal');
+    const card = container.querySelector('.upcoming-goal') as HTMLElement | null;
     card?.click();
 
     expect(handleClick).toHaveBeenCalledTimes(1);
@@ -216,7 +216,7 @@ describe('UpcomingGoalCard', () => {
       />
     );
 
-    const card = container.querySelector('.upcoming-goal');
+    const card = container.querySelector('.upcoming-goal') as HTMLElement | null;
     card?.click();
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
@@ -235,5 +235,33 @@ describe('UpcomingGoalCard', () => {
 
     const lockIcon = container.querySelector('.fas.fa-lock');
     expect(lockIcon).toBeNull();
+  });
+
+  it('locked goal with has_content=true shows lore teaser', () => {
+    const { container } = render(
+      <UpcomingGoalCard
+        goal={{ ...mockGoal, has_content: true }}
+        currentDistance={50}
+        locked={true}
+        onClick={() => {}}
+      />
+    );
+
+    expect(container.textContent).toContain('Campfire lore waits beyond this milestone');
+    expect(container.querySelector('.goal-content-teaser')).toBeTruthy();
+  });
+
+  it('locked goal without content does not show lore teaser', () => {
+    const { container } = render(
+      <UpcomingGoalCard
+        goal={{ ...mockGoal, has_content: false }}
+        currentDistance={50}
+        locked={true}
+        onClick={() => {}}
+      />
+    );
+
+    expect(container.textContent).not.toContain('Campfire lore waits beyond this milestone');
+    expect(container.querySelector('.goal-content-teaser')).toBeNull();
   });
 });

--- a/client/src/islands/UpcomingGoalCard.tsx
+++ b/client/src/islands/UpcomingGoalCard.tsx
@@ -1,18 +1,28 @@
 import type { Goal } from '../types/goal';
+import { useEffect } from 'preact/hooks';
+import { recordGoalContentEvent } from '../utils/goalContentEvents';
 
 interface UpcomingGoalCardProps {
   goal: Goal;
   currentDistance: number;
   locked?: boolean;
   onClick: () => void;
+  partyId?: number | null;
 }
 
 /**
  * UpcomingGoalCard - Preact Island for upcoming goals beyond the next goal
  * Displays goals without progress bar since they're further away
  */
-export function UpcomingGoalCard({ goal, currentDistance, locked = false, onClick }: UpcomingGoalCardProps) {
+export function UpcomingGoalCard({ goal, currentDistance, locked = false, onClick, partyId = null }: UpcomingGoalCardProps) {
   const distanceToGo = goal.distance - currentDistance;
+  const showContentTeaser = locked && goal.has_content === true;
+
+  useEffect(() => {
+    if (showContentTeaser) {
+      recordGoalContentEvent({ goalId: goal.id, eventType: 'teaser_impression', partyId });
+    }
+  }, [showContentTeaser, goal.id, partyId]);
 
   return (
     <div className={`upcoming-goal${locked ? ' goal-locked-interactive' : ''}`} onClick={onClick} style={{ cursor: 'pointer' }}>
@@ -31,6 +41,19 @@ export function UpcomingGoalCard({ goal, currentDistance, locked = false, onClic
           ({distanceToGo.toFixed(2)} km to go)
         </span>
       </span>
+
+      {showContentTeaser && (
+        <div
+          className="goal-content-teaser"
+          aria-label="Locked campfire lore available"
+          style="margin-top: 0.7em; width: 100%; padding: 0.55em 0.7em; border: 1px solid rgba(255, 215, 0, 0.35); border-radius: 8px; background: rgba(255, 215, 0, 0.08); color: #d8c06a; font-size: 0.85em; text-align: center; box-sizing: border-box;"
+        >
+          🔥 Campfire lore waits beyond this milestone
+          <div style="margin-top: 0.25em; filter: blur(3px); color: #aaa; user-select: none;" aria-hidden="true">
+            Ancient words and hidden tales...
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/types/goal.ts
+++ b/client/src/types/goal.ts
@@ -8,4 +8,5 @@ export interface Goal {
   special?: string | null;
   description?: string | null;
   image_id?: string | null;
+  has_content?: boolean;
 }

--- a/client/src/utils/goalContentEvents.ts
+++ b/client/src/utils/goalContentEvents.ts
@@ -1,0 +1,29 @@
+import { getAuthHeaders } from './auth';
+
+export type GoalContentEventType = 'teaser_impression' | 'content_open';
+
+interface GoalContentEventOptions {
+  goalId: number;
+  eventType: GoalContentEventType;
+  partyId?: number | null;
+  contentId?: number | null;
+}
+
+export function recordGoalContentEvent({ goalId, eventType, partyId, contentId }: GoalContentEventOptions): void {
+  try {
+    const body: Record<string, string | number> = {
+      event_type: eventType,
+      context_type: partyId ? 'fellowship' : 'personal',
+    };
+    if (partyId) body.partyId = partyId;
+    if (contentId) body.content_id = contentId;
+
+    void fetch(`/api/goals/${goalId}/content/events`, {
+      method: 'POST',
+      headers: getAuthHeaders(),
+      body: JSON.stringify(body),
+    }).catch(() => undefined);
+  } catch {
+    // Best-effort analytics must never affect UI.
+  }
+}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -5,7 +5,7 @@ description: Complete HTTP API route reference including public, authenticated, 
 
 # API Reference
 
-Last updated: 2026-05-20
+Last updated: 2026-07-17
 
 ## Conventions
 
@@ -21,6 +21,7 @@ Last updated: 2026-05-20
 | Push | `src/push-handlers.ts` |
 | Progress | `src/progress-handlers.ts` |
 | Goals | `src/goals-handlers.ts` |
+| Goal Content | `src/goal-content-handlers.ts`, `src/goal-content-helpers.ts` |
 | Goal Journals | `src/journal-handlers.ts` |
 | Storylines | `src/storyline-handlers.ts`, `src/storyline-utils.ts` |
 | Party (Fellowship) | `src/party-handlers.ts` |
@@ -85,7 +86,32 @@ Last updated: 2026-05-20
 
 | Method | Path | Auth | Notes |
 |---|---|---|---|
-| GET | `/api/goals` | Yes | Active user's storyline goals. Optional `storylineId` query selects another active storyline; admin-only storylines require an admin user. |
+| GET | `/api/goals` | Yes | Active user's storyline goals. Optional `storylineId` query selects another active storyline; admin-only storylines require an admin user. Each goal includes `has_content: boolean`, which is true when any `goal_content` rows exist, including locked goals for teaser UI. |
+
+## Goal Content Endpoints
+
+Goal content is authenticated and uses the same unlock semantics as goal viewing and journals. Without `partyId`, access is evaluated against the user's personal progress. With `partyId`, access is evaluated against the requesting user's active fellowship context.
+
+| Method | Path | Auth | Notes |
+|---|---|---|---|
+| GET | `/api/goals/:goalId/content` | Yes | Optional `partyId=N`. Returns `200 { entries: GoalContentEntry[] }` when the goal is unlocked in the requested context. Returns `403` when locked. Returns an empty `entries` array when unlocked but no content exists. |
+| POST | `/api/goals/:goalId/content/events` | Yes | Body: `{ event_type: 'teaser_impression' | 'content_open', context_type: 'personal' | 'fellowship', content_id?, partyId? }`. Returns `202`. Event writes are best-effort and scheduled with `ExecutionContext.waitUntil`, so analytics failure does not block the user flow. |
+
+`GoalContentEntry` shape:
+
+```json
+{
+  "id": 1,
+  "goal_id": 42,
+  "type": "story",
+  "title": "Campfire at the Crossroads",
+  "body": "Markdown body",
+  "author_attribution": null,
+  "sort_order": 0,
+  "created_at": "2026-07-17T00:00:00.000Z",
+  "updated_at": "2026-07-17T00:00:00.000Z"
+}
+```
 
 ## Goal Journal Endpoints
 
@@ -187,10 +213,15 @@ All admin endpoints require a user with `is_admin = 1`. Non-admin → `403`. Eve
 | GET | `/api/admin/goals/:id` | Single goal detail |
 | POST | `/api/admin/goals` | Create. Accepts `distance_miles` — stored as `miles × 1.60934` km |
 | PUT | `/api/admin/goals/:id` | Update. All fields validated server-side |
+| GET | `/api/admin/goals/:goalId/content` | Lists ordered goal-content entries. Response: `{ entries: GoalContentEntry[] }` |
+| POST | `/api/admin/goals/:goalId/content` | Creates goal content. Body: `{ type, title, body, author_attribution?, sort_order }`. Returns `201 GoalContentEntry`; `400` validation, `404` missing goal, `409` duplicate `sort_order`. |
+| PUT | `/api/admin/goals/:goalId/content/:contentId` | Updates goal content. Returns `200 GoalContentEntry`; `400` validation, `404` missing goal/content, `409` duplicate `sort_order`. |
+| DELETE | `/api/admin/goals/:goalId/content/:contentId` | Deletes goal content. Returns `200 { message }`; `404` if missing. |
 
 - `image_id` must match `/^[a-z0-9]+(-[a-z0-9]+)*$/` or be null/empty. References static assets in `public/img/`.
 - POST uses `distance_miles` (converted to km); PUT uses `distance` (already km).
 - Empty `special` and `image_id` strings normalized to `null`. Goal IDs must be positive integers.
+- Goal content validation limits: `type` must be `story`, `poetry`, or `appendix`; `title` ≤ 120 characters; `author_attribution` ≤ 255 characters; `body` ≤ 20,000 characters; `sort_order` from `0` to `999`.
 
 ### Storyline Management
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ description: System architecture, runtime topology, source tree layout, and proj
 
 # Architecture
 
-Last updated: 2026-06-25
+Last updated: 2026-07-17
 
 ## Project Overview
 
@@ -15,6 +15,7 @@ Feature domains:
 - Account management (register, login, email confirmation, password reset)
 - Personal progress (daily logging, calendar history, milestone unlocking)
 - Interactive map (`/map` with friend markers and hover mini-cards)
+- Goal content / campfire lore attached to unlocked milestones
 - Fellowship system (parties, invites, messaging, unified activity feed)
 - Friends (search, requests, profiles)
 - Avatar system (40+ selectable avatars with slug validation)
@@ -76,6 +77,7 @@ app.get('/api/party/:id/progress', async (c) => {
 |---|---|
 | Auth & profile | `auth-handlers.ts` |
 | Progress & goals | `progress-handlers.ts`, `goals-handlers.ts` |
+| Goal content | `goal-content-handlers.ts`, `goal-content-helpers.ts` |
 | Fellowship | `party-handlers.ts`, `fellowship-invite-handlers.ts` |
 | Friends | `friends-handlers.ts` |
 | Admin | `admin-handlers.ts` (requires `validateAdminSession`) |
@@ -97,7 +99,7 @@ walk-to-mordor/
     css/             # Feature-scoped stylesheets
     js/              # Legacy vanilla JS + Vite-built island bundle (js/client/)
     img/             # Map tiles, avatars, goal images, image-manifest.json
-  migrations/        # D1 SQL migrations (0001–0124)
+  migrations/        # D1 SQL migrations (0001–0141)
   tests/api/         # Jest API tests (miniflare environment)
   tests/ui/          # Playwright E2E specs + helpers/
   scripts/           # Asset pipeline (image optimization, tiling, manifest)
@@ -144,6 +146,13 @@ Feature → file discovery: search `src/` for handler modules, `client/src/islan
 - Admin grant: direct D1 only — `UPDATE users SET is_admin = 1 WHERE username = '...';`
 - All admin actions logged to `admin_audit_log` via `logAdminAction()`.
 
+### Goal Content Unlocks and Discovery Analytics
+
+- Goal content APIs live in `src/goal-content-handlers.ts`; shared row validation, persistence helpers, and analytics writes live in `src/goal-content-helpers.ts`.
+- Goal content does not have a separate lock. Public reads reuse the same goal unlock semantics as goal viewing and milestone journals through `journal-helpers`, including personal progress and optional fellowship `partyId` context.
+- `GET /api/goals` exposes `has_content` so clients can show teaser state for locked goals without receiving content bodies.
+- Discovery analytics (`teaser_impression`, `content_open`) are best-effort background writes. Routes schedule them with Cloudflare Workers `ExecutionContext.waitUntil(...)` so failed analytics inserts do not block modal opens, card rendering, or content reads.
+
 ## Database Layer
 
 D1 is the source of truth. Full schema: `docs/data-models.md`. Migrations in `migrations/`.
@@ -151,12 +160,13 @@ D1 is the source of truth. Full schema: `docs/data-models.md`. Migrations in `mi
 | Domain | Tables |
 |---|---|
 | Core | `users`, `sessions`, `progress`, `goals` |
+| Goal content | `goal_content`, `content_discovery_events` |
 | Auth support | `password_reset_tokens`, `email_confirmation_tokens` |
 | Fellowship | `parties`, `party_members`, `party_progress_log`, `party_messages` |
 | Social | `friendships`, `fellowship_invites` |
 | Admin | `admin_audit_log` |
 
-Migration ranges: 0001–0005 core schema · 0006–0010 auth · 0011–0021 goal updates + email · 0022–0116 goal images · 0117–0118 preferences · 0119–0124 fellowship / social / admin.
+Migration ranges: 0001–0005 core schema · 0006–0010 auth · 0011–0021 goal updates + email · 0022–0116 goal images · 0117–0118 preferences · 0119–0124 fellowship / social / admin · 0125–0139 push, storyline, and journals · 0140–0141 goal content and discovery analytics.
 
 ### Read/Write Separation
 

--- a/docs/data-models.md
+++ b/docs/data-models.md
@@ -5,7 +5,7 @@ description: D1 SQLite schema overview, table relationships, key constraints, an
 
 # Data Models (D1 SQLite)
 
-> Last updated: 2026-05-20 · Migrations: 0001–0138 · Full DDL: `migrations/`
+> Last updated: 2026-07-17 · Migrations: 0001–0141 · Full DDL: `migrations/`
 
 ## Tables
 
@@ -15,6 +15,8 @@ description: D1 SQLite schema overview, table relationships, key constraints, an
 | `sessions` | Active user sessions (token-based) | 0008 |
 | `progress` | Daily walking logs (one entry per user per date) | 0002 |
 | `goals` | Reusable milestone content (title, description, image, default distance compatibility) | 0003 |
+| `goal_content` | Ordered Markdown lore entries attached to canonical goals | 0140 |
+| `content_discovery_events` | Append-only best-effort analytics for goal-content teasers and opens | 0141 |
 | `storylines` | Named journey routes users and fellowships can select | 0132 |
 | `storyline_goals` | Per-storyline goal ordering and distances | 0132 |
 | `password_reset_tokens` | Temporary tokens for password reset flow | 0010 |
@@ -51,6 +53,26 @@ These are rules the schema enforces or that the application layer must uphold �
 - `path_key` lets future storylines select a map path dataset. Unknown client path keys must fall back to the fellowship path until a new path is registered.
 - `storyline_goals` reuses rows from `goals` and stores the storyline-specific `distance` and `sort_order`. This allows the same goal content to appear in multiple routes at different distances.
 - Existing goals are backfilled into `storyline_goals` for `frodo-sam`, preserving current behavior for existing users.
+
+### goal_content
+- Added in migration `0140`.
+- Columns: `id` primary key, `goal_id` foreign key to `goals(id)` with `ON DELETE CASCADE`, `type` text, `title` text, `body` text, `author_attribution` text, `sort_order` integer, `created_at`, and `updated_at`.
+- `type` has a `CHECK` constraint allowing only `story`, `poetry`, or `appendix`.
+- `body` stores Markdown; clients render it as sanitized HTML.
+- `author_attribution` is nullable.
+- `sort_order` has a `CHECK` constraint for the range `0`–`999`.
+- `UNIQUE(goal_id, sort_order)` enforces one ordered content stream per goal.
+- Index: `idx_goal_content_goal_id(goal_id, sort_order)`.
+- Application validation limits: `title` ≤ 120 characters, `author_attribution` ≤ 255 characters, `body` ≤ 20,000 characters, and `sort_order` from `0` to `999`.
+
+### content_discovery_events
+- Added in migration `0141`.
+- Append-only analytics table for goal-content teaser impressions and content opens.
+- Columns: `id` primary key, nullable `user_id`, nullable `party_id`, `goal_id`, nullable `content_id`, `event_type`, `context_type`, and `created_at`.
+- `event_type` has a `CHECK` constraint allowing only `teaser_impression` or `content_open`.
+- `context_type` has a `CHECK` constraint allowing only `personal` or `fellowship`.
+- The table intentionally has no foreign keys. Discovery analytics are best-effort and must not fail user-facing flows if related rows are deleted or event writes are dropped.
+- Indexes exist on `goal_id` and `created_at`.
 
 ### push_subscriptions
 - Stores one row per browser/device subscription endpoint. Multiple rows per user are expected.
@@ -98,9 +120,12 @@ These are rules the schema enforces or that the application layer must uphold �
 |---|---|---|
 | `party_*` tables → `parties.id` | CASCADE | Deleting a party removes all related data |
 | `parties.leader_id` → `users.id` | CASCADE | Leader deletion cascades to party |
+| `goal_content.goal_id` → `goals.id` | CASCADE | Deleting a goal removes its authored lore entries |
 | `email_confirmation_tokens.user_id` | CASCADE | Cleanup on user deletion |
 | `admin_audit_log.admin_user_id` | **No cascade** | Audit records must survive user deletion |
 | All other user FKs | CASCADE | Standard cleanup |
+
+`content_discovery_events` intentionally has no foreign keys because those rows are best-effort analytics.
 
 ## Migration Conventions
 
@@ -108,6 +133,7 @@ These are rules the schema enforces or that the application layer must uphold �
 - Each migration is a single DDL or data-manipulation operation.
 - Schema changes go in migrations; application logic stays in TypeScript.
 - Goal description updates use dedicated migrations (see `0011`–`0019` series).
+- Goal content tables are additive migrations: `0140` for `goal_content`, `0141` for `content_discovery_events`.
 - Deploy: `npx wrangler d1 migrations apply walk-to-mordor-db`.
 
 ## Entity Relationship Diagram
@@ -127,6 +153,7 @@ erDiagram
     users ||--o{ party_messages : "sends"
     users ||--o{ one_more_mile_sent : "receives"
     goals ||--o{ one_more_mile_sent : "targets"
+    goals ||--o{ goal_content : "has lore"
     storylines ||--o{ storyline_goals : "orders"
     goals ||--o{ storyline_goals : "reused by"
     storylines ||--o{ users : "selected by"

--- a/docs/frontend-guide.md
+++ b/docs/frontend-guide.md
@@ -5,7 +5,7 @@ description: Island hydration architecture, component patterns, build tooling, a
 
 # Frontend Guide
 
-Last updated: 2026-05-20
+Last updated: 2026-07-17
 
 ## Frontend Shape
 
@@ -107,6 +107,18 @@ The `GoalModal` component now includes a milestone journal section for goal refl
 - **Context:** Pass `partyId` prop for fellowship-context journal access. Pass `storylineGoalId` for storyline-aware context.
 - **No standalone page:** There is no `/journals` page or journal archive in MVP — GoalModal is the only journal surface.
 
+### GoalModal Goal Content (Campfire Lore)
+
+`GoalModal` also renders unlocked goal content attached to the same canonical goal:
+
+- **Fetching:** On open, unlocked modals request `GET /api/goals/:goalId/content`; fellowship contexts pass `partyId` so the API evaluates the same fellowship unlock state as the modal.
+- **Locked goals:** Locked modals do not fetch content bodies. `NextGoalCard`, `UpcomingGoalCard`, and legacy `public/js/goals.js` use `has_content` to show only a blurred or obscured teaser placeholder on locked goal cards.
+- **Empty state:** If the API returns an empty `entries` array, the content section stays hidden.
+- **Rendering:** Entries are shown in `sort_order` with type badges. `story` entries use the campfire-story treatment, `poetry` entries use centered stanza-friendly presentation, and `appendix` entries use structured long-form presentation.
+- **Markdown:** Bodies render through `marked` and then `DOMPurify`; only sanitized HTML is inserted into the DOM.
+- **Appendices:** Appendix entries show attribution when present. If stripped body text is more than 500 words, the appendix is collapsed by default and provides an expand control.
+- **Admin authoring:** Admins manage entries in the existing `AdminGoalEditIsland`, including Markdown preview with `marked` and `DOMPurify`.
+
 ## Creating a New Island
 
 1. Create `client/src/islands/YourIsland.tsx`.
@@ -147,6 +159,8 @@ Each `src/render*.ts` file produces an SSR shell mounting one or more islands. K
 | Map + Social Panel | `client/src/islands/MapIsland.tsx` |
 | Admin Dashboard | `client/src/islands/AdminDashboardIsland.tsx` |
 | Admin Goals CRUD | `client/src/islands/AdminGoalsListIsland.tsx`, `AdminGoalEditIsland.tsx` |
+| Admin Goal Content | `client/src/islands/AdminGoalEditIsland.tsx` with `marked` + `DOMPurify` Markdown preview |
+| Goal Content Display | `GoalModal`, `NextGoalCard`, `UpcomingGoalCard`, and legacy `public/js/goals.js` |
 | Admin Storylines | `client/src/islands/AdminStorylinesIsland.tsx` |
 | User Storyline Selector | `client/src/islands/ProfileIsland.tsx` |
 | Fellowship Storyline Selector | `client/src/islands/PartyManageIsland.tsx` |
@@ -156,7 +170,7 @@ Each `src/render*.ts` file produces an SSR shell mounting one or more islands. K
 
 ## Legacy JS Interop
 
-Legacy vanilla JS lives in `public/js/`. Key modules: `main.js` (bootstrap), `calendar.js`/`progress.js` (CRUD), `goals.js` (goal list), `validators.js` (shared validation). Profile/preferences is now a Preact island at `/profile` (`ProfileIsland`).
+Legacy vanilla JS lives in `public/js/`. Key modules: `main.js` (bootstrap), `calendar.js`/`progress.js` (CRUD), `goals.js` (goal list), `validators.js` (shared validation). Profile/preferences is now a Preact island at `/profile` (`ProfileIsland`). Goal-content teaser placeholders still touch `goals.js` because the journey goal list has not been fully migrated to islands.
 
 ### Bridge Globals
 
@@ -220,6 +234,8 @@ npm run lint:fix      # Auto-fix fixable issues (e.g., import type suggestions)
 - Use unique mock-auth tokens per test worker for isolation.
 - Playwright route interception blocks auth/hydration — use API pre-configuration (e.g., `PUT /api/user/preferences`) instead of `page.route` for session-dependent test setup.
 - Maintain >90% coverage for new client code.
+- Goal-content client tests should cover admin Markdown preview, locked `has_content` teaser rendering, unlocked content rendering, and appendix truncation/expand behavior.
+- Playwright coverage for goal content should include admin authoring plus user-facing locked versus unlocked flows.
 
 ## Pitfalls & Gotchas
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,20 +5,20 @@ description: Master index of all project documentation with brief descriptions.
 
 # Walk to Mordor Documentation
 
-Last updated: 2026-05-20
+Last updated: 2026-07-17
 
 For documentation guidelines, see [AGENTS.md](AGENTS.md).
 
 ## Core Docs
 
-- [Architecture](architecture.md) — System architecture, runtime topology, source tree layout, and project overview.
-- [Data Models](data-models.md) — D1 schema, relationships, and migration status.
-- [API Reference](api-reference.md) — Complete HTTP API routes including public, authenticated, and admin endpoints.
+- [Architecture](architecture.md) — System architecture, runtime topology, source tree layout, goal-content flow, and project overview.
+- [Data Models](data-models.md) — D1 schema, relationships, migration status, goal content, and discovery analytics.
+- [API Reference](api-reference.md) — Complete HTTP API routes including public, authenticated, admin, and goal-content endpoints.
 - [PRD](prd.md) — Product requirements document.
 
 ## Frontend Docs
 
-- [Frontend Guide](frontend-guide.md) — Island hydration, component patterns, build tooling, and frontend development rules.
+- [Frontend Guide](frontend-guide.md) — Island hydration, component patterns, goal-content UI behavior, build tooling, and frontend development rules.
 - [Design Guide](design-guide.md) — Visual design system, CSS theming, UX patterns, and interaction conventions.
 
 ## Operations Docs

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,7 @@ export default [
   {
     ignores: [
       "node_modules/",
+      ".wrangler/",
       "public/js/client/",
       "coverage/",
       "dist/",

--- a/migrations/0140_create_goal_content.sql
+++ b/migrations/0140_create_goal_content.sql
@@ -1,0 +1,21 @@
+-- Migration 0140_create_goal_content.sql
+-- Create goal_content table for authored rich content attached directly to goals.
+-- Content types: campfire story, poetry, and appendix. One ordered stream per goal.
+
+CREATE TABLE IF NOT EXISTS goal_content (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    goal_id INTEGER NOT NULL,
+    type TEXT NOT NULL CHECK (type IN ('story', 'poetry', 'appendix')),
+    title TEXT NOT NULL,
+    body TEXT NOT NULL,
+    author_attribution TEXT,
+    sort_order INTEGER NOT NULL DEFAULT 0 CHECK (sort_order >= 0 AND sort_order <= 999),
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    -- Content renders as a single ordered stream per goal regardless of type.
+    UNIQUE(goal_id, sort_order),
+    FOREIGN KEY (goal_id) REFERENCES goals (id) ON DELETE CASCADE
+);
+
+-- idx_goal_content_goal_id: fast ordered reads of a goal's content stream
+CREATE INDEX IF NOT EXISTS idx_goal_content_goal_id ON goal_content(goal_id, sort_order);

--- a/migrations/0141_create_content_discovery_events.sql
+++ b/migrations/0141_create_content_discovery_events.sql
@@ -1,0 +1,20 @@
+-- Migration 0141_create_content_discovery_events.sql
+-- Append-only table for lightweight, best-effort goal-content discovery analytics.
+-- Records teaser impressions and content opens. Writes are best-effort and may be
+-- dropped without affecting user-facing flows, so no foreign-key constraints are used.
+
+CREATE TABLE IF NOT EXISTS content_discovery_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    user_id INTEGER,
+    party_id INTEGER,
+    goal_id INTEGER NOT NULL,
+    content_id INTEGER,
+    event_type TEXT NOT NULL CHECK (event_type IN ('teaser_impression', 'content_open')),
+    context_type TEXT NOT NULL CHECK (context_type IN ('personal', 'fellowship')),
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- idx_content_discovery_events_goal_id: aggregate discovery metrics per goal
+CREATE INDEX IF NOT EXISTS idx_content_discovery_events_goal_id ON content_discovery_events(goal_id);
+-- idx_content_discovery_events_created_at: time-window aggregation
+CREATE INDEX IF NOT EXISTS idx_content_discovery_events_created_at ON content_discovery_events(created_at);

--- a/openspec/changes/goal-content-campfire-lore/tasks.md
+++ b/openspec/changes/goal-content-campfire-lore/tasks.md
@@ -1,35 +1,35 @@
 ## 1. Schema And Data Access
 
-- [ ] 1.1 Add D1 migrations for `goal_content` and `content_discovery_events`, including constraints, indexes, and ordered uniqueness by `(goal_id, sort_order)`.
-- [ ] 1.2 Add strict TypeScript row types and database access helpers for goal content records and discovery event writes.
+- [x] 1.1 Add D1 migrations for `goal_content` and `content_discovery_events`, including constraints, indexes, and ordered uniqueness by `(goal_id, sort_order)`.
+- [x] 1.2 Add strict TypeScript row types and database access helpers for goal content records and discovery event writes.
 
 ## 2. Worker APIs And Unlock Logic
 
-- [ ] 2.1 Implement admin goal-content list/create/update/delete handlers with validation for type, title, attribution, shared body limit, and sort order.
-- [ ] 2.2 Wire admin goal-content routes and allowed methods in `src/index.ts`.
-- [ ] 2.3 Implement the public goal-content read endpoint with personal and `partyId`-aware unlock checks that reuse existing goal visibility semantics.
-- [ ] 2.4 Extend `GET /api/goals` to include `has_content` without changing existing goal ordering or lock behavior.
-- [ ] 2.5 Plumb `ExecutionContext` through the Worker request flow so goal-content analytics can be scheduled with non-blocking background writes.
+- [x] 2.1 Implement admin goal-content list/create/update/delete handlers with validation for type, title, attribution, shared body limit, and sort order.
+- [x] 2.2 Wire admin goal-content routes and allowed methods in `src/index.ts`.
+- [x] 2.3 Implement the public goal-content read endpoint with personal and `partyId`-aware unlock checks that reuse existing goal visibility semantics.
+- [x] 2.4 Extend `GET /api/goals` to include `has_content` without changing existing goal ordering or lock behavior.
+- [x] 2.5 Plumb `ExecutionContext` through the Worker request flow so goal-content analytics can be scheduled with non-blocking background writes.
 
 ## 3. Admin Authoring Experience
 
-- [ ] 3.1 Extend the existing admin goal edit island to list ordered content entries and support create, edit, delete, and reorder actions in-place.
-- [ ] 3.2 Reuse the existing Markdown preview flow for goal-content bodies and surface validation errors clearly in the admin form.
+- [x] 3.1 Extend the existing admin goal edit island to list ordered content entries and support create, edit, delete, and reorder actions in-place.
+- [x] 3.2 Reuse the existing Markdown preview flow for goal-content bodies and surface validation errors clearly in the admin form.
 
 ## 4. Public Goal Surfaces
 
-- [ ] 4.1 Update `GoalModal` to fetch goal content, show a loading state, render unlocked entries in `sort_order`, and hide the section when no content exists.
-- [ ] 4.2 Add type-specific rendering treatments for story, poetry, and appendix entries, including appendix attribution and 500-word expand/collapse behavior.
-- [ ] 4.3 Update legacy and island-based goal list/card surfaces to use `has_content` for locked teaser placeholders without exposing unlocked bodies.
+- [x] 4.1 Update `GoalModal` to fetch goal content, show a loading state, render unlocked entries in `sort_order`, and hide the section when no content exists.
+- [x] 4.2 Add type-specific rendering treatments for story, poetry, and appendix entries, including appendix attribution and 500-word expand/collapse behavior.
+- [x] 4.3 Update legacy and island-based goal list/card surfaces to use `has_content` for locked teaser placeholders without exposing unlocked bodies.
 
 ## 5. Discovery Analytics And UX Hardening
 
-- [ ] 5.1 Record best-effort teaser-impression and content-open discovery events without blocking the related user flow.
-- [ ] 5.2 Verify the new `has_content` and goal-content fetch behavior works cleanly with existing cache/versioning expectations and fallback states.
+- [x] 5.1 Record best-effort teaser-impression and content-open discovery events without blocking the related user flow.
+- [x] 5.2 Verify the new `has_content` and goal-content fetch behavior works cleanly with existing cache/versioning expectations and fallback states.
 
 ## 6. Validation And Documentation
 
-- [ ] 6.1 Add backend tests covering goal-content validation, admin permissions, ordered persistence, personal unlock checks, fellowship unlock checks, and analytics failure tolerance.
-- [ ] 6.2 Add frontend tests covering admin Markdown preview, locked teaser rendering, unlocked content rendering, and appendix truncation behavior.
-- [ ] 6.3 Add Playwright coverage for admin authoring and user-facing locked versus unlocked goal-content flows.
-- [ ] 6.4 Update the relevant docs in `docs/` for the new schema, APIs, frontend behavior, and testing expectations.
+- [x] 6.1 Add backend tests covering goal-content validation, admin permissions, ordered persistence, personal unlock checks, fellowship unlock checks, and analytics failure tolerance.
+- [x] 6.2 Add frontend tests covering admin Markdown preview, locked teaser rendering, unlocked content rendering, and appendix truncation behavior.
+- [x] 6.3 Add Playwright coverage for admin authoring and user-facing locked versus unlocked goal-content flows.
+- [x] 6.4 Update the relevant docs in `docs/` for the new schema, APIs, frontend behavior, and testing expectations.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1605,9 +1605,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1625,9 +1622,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1645,9 +1639,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1665,9 +1656,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1685,9 +1673,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1705,9 +1690,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1725,9 +1707,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1745,9 +1724,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1765,9 +1741,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1791,9 +1764,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1817,9 +1787,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1843,9 +1810,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1869,9 +1833,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1895,9 +1856,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1921,9 +1879,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1947,9 +1902,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3211,9 +3163,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3231,9 +3180,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3251,9 +3197,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3271,9 +3214,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3410,9 +3350,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3430,9 +3367,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3450,9 +3384,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3470,9 +3401,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3490,9 +3418,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3510,9 +3435,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8860,9 +8782,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -8880,9 +8799,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -8900,9 +8816,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -8920,9 +8833,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -8940,9 +8850,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -8960,9 +8867,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -8980,9 +8884,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -9000,9 +8901,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -9020,9 +8918,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -9046,9 +8941,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -9072,9 +8964,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -9098,9 +8987,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -9124,9 +9010,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -9150,9 +9033,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -9176,9 +9056,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -9202,9 +9079,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -88,6 +88,7 @@
 /* General application layout */
 body {
   background-color: var(--bg-primary);
+  color: var(--text-primary);
   margin: 0;
   font-family: -apple-system, "Segoe UI", Roboto, sans-serif;
 }

--- a/public/js/goals.js
+++ b/public/js/goals.js
@@ -9,6 +9,34 @@ function getRemainingKm(goal, currentDistance) {
   return Math.max(0, goal.distance - Number(currentDistance));
 }
 
+function recordGoalContentEvent(goal, eventType, partyId, contentId) {
+  if (!goal || !goal.id) return;
+  try {
+    const body = {
+      event_type: eventType,
+      context_type: partyId ? 'fellowship' : 'personal'
+    };
+    if (partyId) body.partyId = partyId;
+    if (contentId) body.content_id = contentId;
+
+    fetch('/api/goals/' + goal.id + '/content/events', {
+      method: 'POST',
+      headers: window.getAuthHeaders(),
+      body: JSON.stringify(body)
+    }).catch(function() {});
+  } catch (e) {
+    // Best-effort analytics only.
+  }
+}
+
+function getGoalContentTeaserHtml(goal) {
+  if (!goal || goal.has_content !== true) return '';
+  return '<div class="goal-content-teaser" aria-label="Locked campfire lore available" style="margin-top:0.7em;width:100%;padding:0.55em 0.7em;border:1px solid rgba(255,215,0,0.35);border-radius:8px;background:rgba(255,215,0,0.08);color:#d8c06a;font-size:0.85em;text-align:center;box-sizing:border-box;">' +
+    '🔥 Campfire lore waits beyond this milestone' +
+    '<div style="margin-top:0.25em;filter:blur(3px);color:#aaa;user-select:none;" aria-hidden="true">Ancient words and hidden tales...</div>' +
+    '</div>';
+}
+
 function showGoalModal(goal, currentDistance, isCongratulations = false, locked = false, partyId = null) {
   // Prevent stacking modals - if one is already open, don't open another
   if (document.getElementById('goal-modal-container')) {
@@ -65,13 +93,13 @@ function showGoalModal(goal, currentDistance, isCongratulations = false, locked 
   );
 }
 
-function makeGoalClickable(element, goal, currentDistance, locked = false) {
+function makeGoalClickable(element, goal, currentDistance, locked = false, partyId = null) {
   if (element) {
     element.style.cursor = 'pointer';
     element.addEventListener('click', function(e) {
       e.preventDefault();
       e.stopPropagation();
-      showGoalModal(goal, currentDistance, false, locked);
+      showGoalModal(goal, currentDistance, false, locked, partyId);
     });
   }
 }
@@ -79,10 +107,12 @@ function makeGoalClickable(element, goal, currentDistance, locked = false) {
 // Track last rendered distance for re-rendering on preference change
 let lastRenderedDistance = null;
 let lastRenderedStorylineId = null;
+let lastRenderedPartyId = null;
 
-function renderGoals(currentDistance, storylineId) {
+function renderGoals(currentDistance, storylineId, partyId = null) {
   lastRenderedDistance = currentDistance;
   lastRenderedStorylineId = storylineId || null;
+  lastRenderedPartyId = partyId || null;
   const goalsUrl = storylineId ? `/api/goals?storylineId=${encodeURIComponent(storylineId)}` : '/api/goals';
   fetch(goalsUrl, {
     headers: window.getAuthHeaders()
@@ -127,8 +157,8 @@ function renderGoals(currentDistance, storylineId) {
         queueMicrotask(() => {
           const headerMain = document.querySelector('.goal-header-main');
           const headerSpecial = document.querySelector('.goal-header-special');
-          if (headerMain) makeGoalClickable(headerMain, lastGoal, currentDistance);
-          if (headerSpecial && lastSpecial) makeGoalClickable(headerSpecial, lastSpecial, currentDistance);
+          if (headerMain) makeGoalClickable(headerMain, lastGoal, currentDistance, false, partyId);
+          if (headerSpecial && lastSpecial) makeGoalClickable(headerSpecial, lastSpecial, currentDistance, false, partyId);
         });
       } else {
         document.getElementById('last-goal').innerHTML = '';
@@ -229,7 +259,8 @@ function renderGoals(currentDistance, storylineId) {
                   currentDistance: Number(currentDistance),
                   previousDistance: previousDistance,
                   locked: !prefUnlocked,
-                  onClick: () => showGoalModal(nextGoal, currentDistance, false, !prefUnlocked)
+                  onClick: () => showGoalModal(nextGoal, currentDistance, false, !prefUnlocked, partyId),
+                  partyId: partyId
                 }),
                 nextGoalMount
               );
@@ -253,13 +284,18 @@ function renderGoals(currentDistance, storylineId) {
                 (nextGoal.special ? '<span style="display:block;color:#FFD700;font-size:1.3em;font-weight:bold;margin-bottom:0.2em;">' + nextGoal.special + '</span>' : '') +
                 '<span style="font-size:1.1em;color:#fff;font-weight:bold;max-width:90vw;">' + (!prefUnlocked ? '<i class="fas fa-lock" style="margin-right:0.4em;font-size:0.85em;color:#888;"></i>' : '') + nextGoal.title + '</span>' +
                 '<span style="font-size:0.95em;color:#FFD700;margin-top:0.2em;">' + nextGoal.distance.toFixed(2) + ' km <span style="color:#aaa;font-size:0.9em;">(' + getRemainingKm(nextGoal, currentDistance).toFixed(2) + ' km to go)</span></span>' +
+                (!prefUnlocked ? getGoalContentTeaserHtml(nextGoal) : '') +
                 '<div class="goal-progress-track" style="width:100%;height:8px;background:rgba(0,0,0,0.5);border-radius:4px;margin-top:0.6em;overflow:hidden;">' +
                   '<div class="goal-progress-fill" style="width:' + percentage.toFixed(1) + '%;min-width:' + fillMinWidth + ';height:100%;background:#FFD700;transition:width 0.3s ease;"></div>' +
                 '</div>' +
                 '</div>';
 
+              if (!prefUnlocked && nextGoal.has_content === true) {
+                recordGoalContentEvent(nextGoal, 'teaser_impression', partyId);
+              }
+
               // Make fallback always clickable
-              makeGoalClickable(nextGoalMount.querySelector('.next-goal'), nextGoal, currentDistance, !prefUnlocked);
+              makeGoalClickable(nextGoalMount.querySelector('.next-goal'), nextGoal, currentDistance, !prefUnlocked, partyId);
             }
 
             // Always apply next-target styling to the first upcoming goal
@@ -293,7 +329,8 @@ function renderGoals(currentDistance, storylineId) {
                   goal: goal,
                   currentDistance: Number(currentDistance),
                   locked: !prefUnlocked,
-                  onClick: () => showGoalModal(goal, currentDistance, false, !prefUnlocked)
+                  onClick: () => showGoalModal(goal, currentDistance, false, !prefUnlocked, partyId),
+                  partyId: partyId
                 }),
                 mountPoint
               );
@@ -324,22 +361,27 @@ function renderGoals(currentDistance, storylineId) {
                 (goal.special ? '<span style="display:block;color:#FFD700;font-size:1.3em;font-weight:bold;margin-bottom:0.2em;">' + goal.special + '</span>' : '') +
                 '<span style="font-size:1.1em;color:#fff;font-weight:bold;max-width:90vw;">' + (!prefUnlocked ? '<i class="fas fa-lock" style="margin-right:0.4em;font-size:0.85em;color:#888;"></i>' : '') + goal.title + '</span>' +
                 '<span style="font-size:0.95em;color:#FFD700;margin-top:0.2em;">' + goal.distance.toFixed(2) + ' km <span style="color:#aaa;font-size:0.9em;">(' + getRemainingKm(goal, currentDistance).toFixed(2) + ' km to go)</span></span>' +
+                (!prefUnlocked ? getGoalContentTeaserHtml(goal) : '') +
                 '</div>';
 
+              if (!prefUnlocked && goal.has_content === true) {
+                recordGoalContentEvent(goal, 'teaser_impression', partyId);
+              }
+
               // Make fallback always clickable
-              makeGoalClickable(mountPoint.querySelector('.upcoming-goal'), goal, currentDistance, !prefUnlocked);
+              makeGoalClickable(mountPoint.querySelector('.upcoming-goal'), goal, currentDistance, !prefUnlocked, partyId);
             }
           });
         }
 
         // Completed goals (last 3)
         document.querySelectorAll('.completed-goal').forEach((element, index) => {
-          makeGoalClickable(element, lastCompleted[index], currentDistance);
+          makeGoalClickable(element, lastCompleted[index], currentDistance, false, partyId);
         });
 
         // All completed goals
         document.querySelectorAll('.all-completed-goal').forEach((element, index) => {
-          makeGoalClickable(element, completed[index], currentDistance);
+          makeGoalClickable(element, completed[index], currentDistance, false, partyId);
         });
       });
     })
@@ -420,7 +462,7 @@ window.goalsModule = {
 // Re-render goals when preference changes (dynamic toggle reactivity)
 window.addEventListener('preferenceChanged', function() {
   if (lastRenderedDistance !== null) {
-    renderGoals(lastRenderedDistance, lastRenderedStorylineId);
+    renderGoals(lastRenderedDistance, lastRenderedStorylineId, lastRenderedPartyId);
   }
 });
 
@@ -454,7 +496,7 @@ function mountPartySelector() {
         el.textContent = pd + ' km';
       }
       if (pd !== undefined) {
-        renderGoals(pd);
+        renderGoals(pd, null, null);
       }
     } else if (progress) {
       // Show party progress
@@ -462,7 +504,7 @@ function mountPartySelector() {
       if (el) {
         el.textContent = progress.total_distance.toFixed(2) + ' km';
       }
-      renderGoals(progress.total_distance, progress.active_storyline && progress.active_storyline.id);
+      renderGoals(progress.total_distance, progress.active_storyline && progress.active_storyline.id, typeof selection === 'number' ? selection : null);
     }
   }
 
@@ -474,7 +516,10 @@ function mountPartySelector() {
           ? window.partyStore.partyProgress.value.total_distance
           : (window._personalDistance || 0);
         setTimeout(function() {
-          window.goalsModule.showGoalModal(latest, currentDist, true);
+          var selectedPartyId = window.partyStore && typeof window.partyStore.selectedView.value === 'number'
+            ? window.partyStore.selectedView.value
+            : null;
+          window.goalsModule.showGoalModal(latest, currentDist, true, false, selectedPartyId);
         }, 300);
       }
     }

--- a/src/goal-content-handlers.ts
+++ b/src/goal-content-handlers.ts
@@ -1,0 +1,308 @@
+// Goal content API handlers: admin CRUD, public unlock-aware reads, and discovery analytics.
+import { validateSession } from './auth-handlers';
+import type { DbClient } from './db';
+import { logAdminAction } from './admin-handlers';
+import {
+  hasUserReachedGoal,
+  hasFellowshipReachedGoal,
+  hasAnyFellowshipReachedGoal,
+  isActivePartyMember,
+} from './journal-helpers';
+import {
+  listGoalContent,
+  getGoalContentById,
+  createGoalContent,
+  updateGoalContent,
+  deleteGoalContent,
+  recordDiscoveryEvent,
+  validateGoalContentInput,
+  DuplicateSortOrderError,
+  GOAL_CONTENT_TYPES,
+  type DiscoveryEventType,
+  type DiscoveryContextType,
+} from './goal-content-helpers';
+
+// ── Response helpers ───────────────────────────────────────────────────────
+
+function jsonError(error: string, status = 400): Response {
+  return new Response(JSON.stringify({ error }), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function jsonOk(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ADMIN HANDLERS
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** GET /api/admin/goals/:goalId/content */
+export async function handleAdminGoalContentList(
+  _request: Request,
+  db: DbClient,
+  goalId: number,
+): Promise<Response> {
+  try {
+    const entries = await listGoalContent(db, goalId);
+    return jsonOk({ entries });
+  } catch (error) {
+    console.error('Error listing goal content:', error);
+    return jsonError('Internal server error while listing goal content', 500);
+  }
+}
+
+/** POST /api/admin/goals/:goalId/content */
+export async function handleAdminGoalContentCreate(
+  request: Request,
+  db: DbClient,
+  goalId: number,
+  body: unknown,
+  adminUserId: number,
+): Promise<Response> {
+  try {
+    // Ensure the goal exists before attaching content.
+    const goal = await db.read.prepare('SELECT id FROM goals WHERE id = ?').bind(goalId).first<{ id: number }>();
+    if (!goal) {
+      return jsonError('Goal not found', 404);
+    }
+
+    const validation = validateGoalContentInput(body);
+    if (!validation.ok) {
+      return jsonError(validation.error, 400);
+    }
+
+    const created = await createGoalContent(db, goalId, validation.value);
+
+    await logAdminAction(db, {
+      adminUserId,
+      action: 'create_goal_content',
+      targetType: 'goal_content',
+      targetId: created.id,
+      details: JSON.stringify({ goalId, type: created.type, sort_order: created.sort_order }),
+      ipAddress: request.headers.get('CF-Connecting-IP') || 'unknown',
+      success: true,
+    });
+
+    return jsonOk(created, 201);
+  } catch (error) {
+    if (error instanceof DuplicateSortOrderError) {
+      return jsonError(error.message, 409);
+    }
+    console.error('Error creating goal content:', error);
+    return jsonError('Internal server error while creating goal content', 500);
+  }
+}
+
+/** PUT /api/admin/goals/:goalId/content/:contentId */
+export async function handleAdminGoalContentUpdate(
+  request: Request,
+  db: DbClient,
+  goalId: number,
+  contentId: number,
+  body: unknown,
+  adminUserId: number,
+): Promise<Response> {
+  try {
+    const existing = await getGoalContentById(db, contentId);
+    if (!existing || existing.goal_id !== goalId) {
+      return jsonError('Goal content not found', 404);
+    }
+
+    const validation = validateGoalContentInput(body);
+    if (!validation.ok) {
+      return jsonError(validation.error, 400);
+    }
+
+    const updated = await updateGoalContent(db, contentId, validation.value);
+    if (!updated) {
+      return jsonError('Goal content not found', 404);
+    }
+
+    await logAdminAction(db, {
+      adminUserId,
+      action: 'update_goal_content',
+      targetType: 'goal_content',
+      targetId: contentId,
+      details: JSON.stringify({ goalId, type: updated.type, sort_order: updated.sort_order }),
+      ipAddress: request.headers.get('CF-Connecting-IP') || 'unknown',
+      success: true,
+    });
+
+    return jsonOk(updated);
+  } catch (error) {
+    if (error instanceof DuplicateSortOrderError) {
+      return jsonError(error.message, 409);
+    }
+    console.error('Error updating goal content:', error);
+    return jsonError('Internal server error while updating goal content', 500);
+  }
+}
+
+/** DELETE /api/admin/goals/:goalId/content/:contentId */
+export async function handleAdminGoalContentDelete(
+  request: Request,
+  db: DbClient,
+  goalId: number,
+  contentId: number,
+  adminUserId: number,
+): Promise<Response> {
+  try {
+    const existing = await getGoalContentById(db, contentId);
+    if (!existing || existing.goal_id !== goalId) {
+      return jsonError('Goal content not found', 404);
+    }
+
+    await deleteGoalContent(db, contentId);
+
+    await logAdminAction(db, {
+      adminUserId,
+      action: 'delete_goal_content',
+      targetType: 'goal_content',
+      targetId: contentId,
+      details: JSON.stringify({ goalId }),
+      ipAddress: request.headers.get('CF-Connecting-IP') || 'unknown',
+      success: true,
+    });
+
+    return jsonOk({ message: 'Goal content deleted' });
+  } catch (error) {
+    console.error('Error deleting goal content:', error);
+    return jsonError('Internal server error while deleting goal content', 500);
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PUBLIC HANDLERS
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** Parse an integer query/path value or return an error Response. */
+function parseIntParam(value: string, name: string): number | Response {
+  const num = Number.parseInt(value, 10);
+  if (!Number.isInteger(num) || num <= 0 || String(num) !== value) {
+    return jsonError(`Invalid ${name}`, 400);
+  }
+  return num;
+}
+
+/**
+ * GET /api/goals/:goalId/content[?partyId=<id>]
+ *
+ * Returns a goal's authored content entries, but only when the goal is unlocked
+ * in the requested viewing context. Reuses the exact goal unlock semantics:
+ * - Without partyId: personal storyline-aware progress.
+ * - With partyId: fellowship progress for that party (requires active membership).
+ *
+ * Locked context -> 403. Unlocked context with no entries -> empty array.
+ */
+export async function handleGoalContentGet(
+  request: Request,
+  db: DbClient,
+  goalId: number,
+  allowTestAuth?: string,
+): Promise<Response> {
+  const sessionValidation = await validateSession(request, db, allowTestAuth);
+  if (!sessionValidation.valid) return sessionValidation.error;
+
+  const userId = sessionValidation.userId;
+
+  try {
+    const url = new URL(request.url);
+    const partyIdParam = url.searchParams.get('partyId');
+    let partyId: number | null = null;
+
+    if (partyIdParam !== null) {
+      const parsed = parseIntParam(partyIdParam, 'partyId');
+      if (parsed instanceof Response) return parsed;
+      partyId = parsed;
+
+      const isMember = await isActivePartyMember(db, userId, partyId);
+      if (!isMember) {
+        return jsonError('You are not an active member of this fellowship', 403);
+      }
+    }
+
+    // Reuse the same unlock semantics as the goal surface itself.
+    const personalReach = await hasUserReachedGoal(db, userId, goalId);
+    let unlocked = personalReach;
+    if (!unlocked) {
+      unlocked = partyId !== null
+        ? await hasFellowshipReachedGoal(db, partyId, goalId)
+        : await hasAnyFellowshipReachedGoal(db, userId, goalId);
+    }
+
+    if (!unlocked) {
+      return jsonError('This goal content is locked', 403);
+    }
+
+    const entries = await listGoalContent(db, goalId);
+    return jsonOk({ entries });
+  } catch (error) {
+    console.error('Error reading goal content:', error);
+    return jsonError('Internal server error while reading goal content', 500);
+  }
+}
+
+/**
+ * POST /api/goals/:goalId/content/events
+ *
+ * Records a best-effort discovery event. The write is scheduled via
+ * ctx.waitUntil so it never blocks the response, and failures are swallowed.
+ * Always returns 202 for well-formed requests.
+ */
+export async function handleContentDiscoveryEvent(
+  request: Request,
+  db: DbClient,
+  goalId: number,
+  body: Record<string, unknown>,
+  scheduleBackground: (promise: Promise<unknown>) => void,
+  allowTestAuth?: string,
+): Promise<Response> {
+  const sessionValidation = await validateSession(request, db, allowTestAuth);
+  if (!sessionValidation.valid) return sessionValidation.error;
+
+  const userId = sessionValidation.userId;
+
+  const eventType = body?.event_type;
+  const contextType = body?.context_type;
+
+  const validEventTypes: DiscoveryEventType[] = ['teaser_impression', 'content_open'];
+  const validContextTypes: DiscoveryContextType[] = ['personal', 'fellowship'];
+
+  if (typeof eventType !== 'string' || !validEventTypes.includes(eventType as DiscoveryEventType)) {
+    return jsonError('Invalid event_type', 400);
+  }
+  if (typeof contextType !== 'string' || !validContextTypes.includes(contextType as DiscoveryContextType)) {
+    return jsonError('Invalid context_type', 400);
+  }
+
+  let partyId: number | null = null;
+  if (typeof body.partyId === 'number' && Number.isInteger(body.partyId) && body.partyId > 0) {
+    partyId = body.partyId;
+  }
+  let contentId: number | null = null;
+  if (typeof body.content_id === 'number' && Number.isInteger(body.content_id) && body.content_id > 0) {
+    contentId = body.content_id;
+  }
+
+  // Best-effort: schedule the write and return immediately.
+  scheduleBackground(
+    recordDiscoveryEvent(db, {
+      userId,
+      partyId,
+      goalId,
+      contentId,
+      eventType: eventType as DiscoveryEventType,
+      contextType: contextType as DiscoveryContextType,
+    }),
+  );
+
+  return jsonOk({ accepted: true }, 202);
+}
+
+export { GOAL_CONTENT_TYPES };

--- a/src/goal-content-handlers.ts
+++ b/src/goal-content-handlers.ts
@@ -17,7 +17,6 @@ import {
   recordDiscoveryEvent,
   validateGoalContentInput,
   DuplicateSortOrderError,
-  GOAL_CONTENT_TYPES,
   type DiscoveryEventType,
   type DiscoveryContextType,
 } from './goal-content-helpers';
@@ -305,4 +304,3 @@ export async function handleContentDiscoveryEvent(
   return jsonOk({ accepted: true }, 202);
 }
 
-export { GOAL_CONTENT_TYPES };

--- a/src/goal-content-helpers.ts
+++ b/src/goal-content-helpers.ts
@@ -1,0 +1,300 @@
+// Goal content data-access helpers, row types, and validation for authored goal content.
+import type { DbClient } from './db';
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type GoalContentType = 'story' | 'poetry' | 'appendix';
+
+export const GOAL_CONTENT_TYPES: readonly GoalContentType[] = ['story', 'poetry', 'appendix'];
+
+/** Row shape from the goal_content table. */
+export interface GoalContentRow {
+  id: number;
+  goal_id: number;
+  type: GoalContentType;
+  title: string;
+  body: string;
+  author_attribution: string | null;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Client-facing goal content entry (matches DB columns for simplicity). */
+export interface GoalContentEntry {
+  id: number;
+  goal_id: number;
+  type: GoalContentType;
+  title: string;
+  body: string;
+  author_attribution: string | null;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Validated input for creating/updating a goal content entry. */
+export interface GoalContentInput {
+  type: GoalContentType;
+  title: string;
+  body: string;
+  author_attribution: string | null;
+  sort_order: number;
+}
+
+/** Discovery event types and context. */
+export type DiscoveryEventType = 'teaser_impression' | 'content_open';
+export type DiscoveryContextType = 'personal' | 'fellowship';
+
+export interface DiscoveryEventInput {
+  userId: number | null;
+  partyId: number | null;
+  goalId: number;
+  contentId: number | null;
+  eventType: DiscoveryEventType;
+  contextType: DiscoveryContextType;
+}
+
+// ── Validation ─────────────────────────────────────────────────────────────
+
+export const GOAL_CONTENT_LIMITS = {
+  TITLE_MAX: 120,
+  ATTRIBUTION_MAX: 255,
+  BODY_MAX: 20000,
+  SORT_ORDER_MIN: 0,
+  SORT_ORDER_MAX: 999,
+} as const;
+
+export type ValidationResult =
+  | { ok: true; value: GoalContentInput }
+  | { ok: false; error: string };
+
+/**
+ * Validate an admin-supplied goal content payload.
+ * Enforces type, title, attribution, shared body limit, and sort order range.
+ */
+export function validateGoalContentInput(body: unknown): ValidationResult {
+  if (!body || typeof body !== 'object') {
+    return { ok: false, error: 'Invalid request body' };
+  }
+  const data = body as Record<string, unknown>;
+
+  const type = data.type;
+  if (typeof type !== 'string' || !GOAL_CONTENT_TYPES.includes(type as GoalContentType)) {
+    return { ok: false, error: 'Type must be one of: story, poetry, appendix' };
+  }
+
+  const title = typeof data.title === 'string' ? data.title.trim() : '';
+  if (!title) {
+    return { ok: false, error: 'Title is required' };
+  }
+  if (title.length > GOAL_CONTENT_LIMITS.TITLE_MAX) {
+    return { ok: false, error: `Title must be ${GOAL_CONTENT_LIMITS.TITLE_MAX} characters or less` };
+  }
+
+  const body_ = typeof data.body === 'string' ? data.body : '';
+  if (!body_.trim()) {
+    return { ok: false, error: 'Body is required' };
+  }
+  if (body_.length > GOAL_CONTENT_LIMITS.BODY_MAX) {
+    return { ok: false, error: `Body must be ${GOAL_CONTENT_LIMITS.BODY_MAX} characters or less` };
+  }
+
+  let attribution: string | null = null;
+  if (data.author_attribution !== undefined && data.author_attribution !== null) {
+    if (typeof data.author_attribution !== 'string') {
+      return { ok: false, error: 'Attribution must be a string' };
+    }
+    const trimmed = data.author_attribution.trim();
+    if (trimmed.length > GOAL_CONTENT_LIMITS.ATTRIBUTION_MAX) {
+      return { ok: false, error: `Attribution must be ${GOAL_CONTENT_LIMITS.ATTRIBUTION_MAX} characters or less` };
+    }
+    attribution = trimmed.length > 0 ? trimmed : null;
+  }
+
+  const rawSort = data.sort_order;
+  if (typeof rawSort !== 'number' || !Number.isInteger(rawSort)) {
+    return { ok: false, error: 'Sort order must be an integer' };
+  }
+  if (rawSort < GOAL_CONTENT_LIMITS.SORT_ORDER_MIN || rawSort > GOAL_CONTENT_LIMITS.SORT_ORDER_MAX) {
+    return {
+      ok: false,
+      error: `Sort order must be between ${GOAL_CONTENT_LIMITS.SORT_ORDER_MIN} and ${GOAL_CONTENT_LIMITS.SORT_ORDER_MAX}`,
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      type: type as GoalContentType,
+      title,
+      body: body_,
+      author_attribution: attribution,
+      sort_order: rawSort,
+    },
+  };
+}
+
+// ── Data Access ────────────────────────────────────────────────────────────
+
+function toEntry(row: GoalContentRow): GoalContentEntry {
+  return {
+    id: row.id,
+    goal_id: row.goal_id,
+    type: row.type,
+    title: row.title,
+    body: row.body,
+    author_attribution: row.author_attribution ?? null,
+    sort_order: row.sort_order,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+/** List a goal's content entries ordered by sort_order ascending. */
+export async function listGoalContent(db: DbClient, goalId: number): Promise<GoalContentEntry[]> {
+  const { results } = await db.read.prepare(
+    `SELECT id, goal_id, type, title, body, author_attribution, sort_order, created_at, updated_at
+     FROM goal_content
+     WHERE goal_id = ?
+     ORDER BY sort_order ASC, id ASC`,
+  ).bind(goalId).all<GoalContentRow>();
+
+  return (results || []).map(toEntry);
+}
+
+/** Fetch a single content entry by id. Returns null if not found. */
+export async function getGoalContentById(db: DbClient, contentId: number): Promise<GoalContentEntry | null> {
+  const row = await db.read.prepare(
+    `SELECT id, goal_id, type, title, body, author_attribution, sort_order, created_at, updated_at
+     FROM goal_content
+     WHERE id = ?`,
+  ).bind(contentId).first<GoalContentRow>();
+
+  return row ? toEntry(row) : null;
+}
+
+/** Thrown when a create/update would collide with an existing (goal_id, sort_order). */
+export class DuplicateSortOrderError extends Error {
+  constructor() {
+    super('A content entry with this sort order already exists for this goal');
+    this.name = 'DuplicateSortOrderError';
+  }
+}
+
+/** Check whether a goal already has an entry at a given sort order (optionally excluding one id). */
+async function sortOrderTaken(
+  db: DbClient,
+  goalId: number,
+  sortOrder: number,
+  excludeContentId?: number,
+): Promise<boolean> {
+  const row = excludeContentId === undefined
+    ? await db.read.prepare(
+      `SELECT id FROM goal_content WHERE goal_id = ? AND sort_order = ? LIMIT 1`,
+    ).bind(goalId, sortOrder).first<{ id: number }>()
+    : await db.read.prepare(
+      `SELECT id FROM goal_content WHERE goal_id = ? AND sort_order = ? AND id != ? LIMIT 1`,
+    ).bind(goalId, sortOrder, excludeContentId).first<{ id: number }>();
+  return row !== null;
+}
+
+/** Create a content entry for a goal. Throws DuplicateSortOrderError on sort_order collision. */
+export async function createGoalContent(
+  db: DbClient,
+  goalId: number,
+  input: GoalContentInput,
+): Promise<GoalContentEntry> {
+  if (await sortOrderTaken(db, goalId, input.sort_order)) {
+    throw new DuplicateSortOrderError();
+  }
+
+  const result = await db.write.prepare(
+    `INSERT INTO goal_content (goal_id, type, title, body, author_attribution, sort_order)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).bind(
+    goalId,
+    input.type,
+    input.title,
+    input.body,
+    input.author_attribution,
+    input.sort_order,
+  ).run();
+
+  const newId = result.meta.last_row_id as number;
+  const created = await getGoalContentById(db, newId);
+  if (!created) {
+    throw new Error('Failed to fetch created goal content');
+  }
+  return created;
+}
+
+/** Update a content entry. Throws DuplicateSortOrderError on sort_order collision. */
+export async function updateGoalContent(
+  db: DbClient,
+  contentId: number,
+  input: GoalContentInput,
+): Promise<GoalContentEntry | null> {
+  const existing = await getGoalContentById(db, contentId);
+  if (!existing) return null;
+
+  if (await sortOrderTaken(db, existing.goal_id, input.sort_order, contentId)) {
+    throw new DuplicateSortOrderError();
+  }
+
+  const now = new Date().toISOString();
+  await db.write.prepare(
+    `UPDATE goal_content
+     SET type = ?, title = ?, body = ?, author_attribution = ?, sort_order = ?, updated_at = ?
+     WHERE id = ?`,
+  ).bind(
+    input.type,
+    input.title,
+    input.body,
+    input.author_attribution,
+    input.sort_order,
+    now,
+    contentId,
+  ).run();
+
+  return getGoalContentById(db, contentId);
+}
+
+/** Delete a content entry. Returns true if a row was deleted. */
+export async function deleteGoalContent(db: DbClient, contentId: number): Promise<boolean> {
+  const result = await db.write.prepare(
+    `DELETE FROM goal_content WHERE id = ?`,
+  ).bind(contentId).run();
+  return result.meta.changes > 0;
+}
+
+/** Whether a goal has one or more content entries. */
+export async function goalHasContent(db: DbClient, goalId: number): Promise<boolean> {
+  const row = await db.read.prepare(
+    `SELECT 1 as present FROM goal_content WHERE goal_id = ? LIMIT 1`,
+  ).bind(goalId).first<{ present: number }>();
+  return row !== null;
+}
+
+/**
+ * Record a discovery event on a best-effort basis.
+ * Errors are logged and swallowed so callers never fail user-facing flows.
+ */
+export async function recordDiscoveryEvent(db: DbClient, event: DiscoveryEventInput): Promise<void> {
+  try {
+    await db.write.prepare(
+      `INSERT INTO content_discovery_events
+        (user_id, party_id, goal_id, content_id, event_type, context_type)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).bind(
+      event.userId,
+      event.partyId,
+      event.goalId,
+      event.contentId,
+      event.eventType,
+      event.contextType,
+    ).run();
+  } catch (error) {
+    console.error('Failed to record content discovery event:', error);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -291,6 +291,7 @@ app.post('/api/goals/:goalId/content/events', authGuard, async (c) => {
   if (goalId instanceof Response) return goalId;
   const body = await safeJsonBody(c);
   // Plumb ExecutionContext so discovery writes run as non-blocking background work.
+  /* istanbul ignore next -- executionCtx.waitUntil is a Cloudflare-only runtime API */
   const schedule = (promise: Promise<unknown>) => {
     try {
       c.executionCtx.waitUntil(promise);

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,14 @@ import {
   calculateUserStorylineDistance
 } from "./goals-handlers";
 import {
+  handleAdminGoalContentList,
+  handleAdminGoalContentCreate,
+  handleAdminGoalContentUpdate,
+  handleAdminGoalContentDelete,
+  handleGoalContentGet,
+  handleContentDiscoveryEvent,
+} from "./goal-content-handlers";
+import {
   handleJournalStateGet,
   handleJournalUpsert,
   handleJournalDelete
@@ -272,6 +280,28 @@ app.delete('/api/goals/:goalId/journal', authGuard, async (c) => {
   return handleJournalDelete(c.req.raw, c.get('db'), goalId, c.env.ALLOW_TEST_AUTH);
 });
 
+// ── Goal Content (unlock-aware reads + discovery analytics) ──
+app.get('/api/goals/:goalId/content', authGuard, async (c) => {
+  const goalId = intParam(c.req.param('goalId'), 'goalId');
+  if (goalId instanceof Response) return goalId;
+  return handleGoalContentGet(c.req.raw, c.get('db'), goalId, c.env.ALLOW_TEST_AUTH);
+});
+app.post('/api/goals/:goalId/content/events', authGuard, async (c) => {
+  const goalId = intParam(c.req.param('goalId'), 'goalId');
+  if (goalId instanceof Response) return goalId;
+  const body = await safeJsonBody(c);
+  // Plumb ExecutionContext so discovery writes run as non-blocking background work.
+  const schedule = (promise: Promise<unknown>) => {
+    try {
+      c.executionCtx.waitUntil(promise);
+    } catch {
+      // No execution context available (e.g. tests) — swallow, best-effort only.
+      void promise;
+    }
+  };
+  return handleContentDiscoveryEvent(c.req.raw, c.get('db'), goalId, body, schedule, c.env.ALLOW_TEST_AUTH);
+});
+
 app.get('/api/stats/weekly', authGuard, (c) =>
   handleWeeklyStats(c.req.raw, c.get('db'), c.env.ALLOW_TEST_AUTH));
 app.get('/api/stats/heatmap', authGuard, (c) =>
@@ -477,6 +507,32 @@ app.put('/api/admin/goals/:id', adminGuard, async (c) => {
   const goalId = intParam(c.req.param('id'), 'goal ID');
   if (goalId instanceof Response) return goalId;
   return handleAdminGoalUpdate(c.req.raw, c.get('db'), goalId, await c.req.json(), c.get('adminUserId')!);
+});
+
+// ── Goal Content (admin CRUD) ──
+app.get('/api/admin/goals/:goalId/content', adminGuard, async (c) => {
+  const goalId = intParam(c.req.param('goalId'), 'goal ID');
+  if (goalId instanceof Response) return goalId;
+  return handleAdminGoalContentList(c.req.raw, c.get('db'), goalId);
+});
+app.post('/api/admin/goals/:goalId/content', adminGuard, async (c) => {
+  const goalId = intParam(c.req.param('goalId'), 'goal ID');
+  if (goalId instanceof Response) return goalId;
+  return handleAdminGoalContentCreate(c.req.raw, c.get('db'), goalId, await safeJsonBody(c), c.get('adminUserId')!);
+});
+app.put('/api/admin/goals/:goalId/content/:contentId', adminGuard, async (c) => {
+  const goalId = intParam(c.req.param('goalId'), 'goal ID');
+  if (goalId instanceof Response) return goalId;
+  const contentId = intParam(c.req.param('contentId'), 'content ID');
+  if (contentId instanceof Response) return contentId;
+  return handleAdminGoalContentUpdate(c.req.raw, c.get('db'), goalId, contentId, await safeJsonBody(c), c.get('adminUserId')!);
+});
+app.delete('/api/admin/goals/:goalId/content/:contentId', adminGuard, async (c) => {
+  const goalId = intParam(c.req.param('goalId'), 'goal ID');
+  if (goalId instanceof Response) return goalId;
+  const contentId = intParam(c.req.param('contentId'), 'content ID');
+  if (contentId instanceof Response) return contentId;
+  return handleAdminGoalContentDelete(c.req.raw, c.get('db'), goalId, contentId, c.get('adminUserId')!);
 });
 
 // ── Storylines ──

--- a/src/storyline-utils.ts
+++ b/src/storyline-utils.ts
@@ -27,6 +27,7 @@ export interface StorylineGoal {
   image_id: string | null;
   special: string | null;
   sort_order: number;
+  has_content: boolean;
 }
 
 interface StorylineRow {
@@ -205,12 +206,13 @@ export async function listStorylineGoals(db: DbClient, storylineId: number): Pro
             g.description,
             g.image_id,
             g.special,
-            sg.sort_order
+            sg.sort_order,
+            EXISTS(SELECT 1 FROM goal_content gc WHERE gc.goal_id = g.id) as has_content
      FROM storyline_goals sg
      JOIN goals g ON g.id = sg.goal_id
      WHERE sg.storyline_id = ?
      ORDER BY sg.distance ASC, sg.sort_order ASC, g.id ASC`,
-  ).bind(storylineId).all<StorylineGoal>();
+  ).bind(storylineId).all<Omit<StorylineGoal, 'has_content'> & { has_content: number }>();
 
   return results.map((goal) => ({
     storyline_goal_id: goal.storyline_goal_id,
@@ -221,6 +223,7 @@ export async function listStorylineGoals(db: DbClient, storylineId: number): Pro
     image_id: goal.image_id ?? null,
     special: goal.special ?? null,
     sort_order: goal.sort_order,
+    has_content: Number(goal.has_content) === 1,
   }));
 }
 

--- a/tests/api/goal-content-handlers.test.ts
+++ b/tests/api/goal-content-handlers.test.ts
@@ -1,0 +1,583 @@
+import { DbClient } from '../../src/db';
+import type { GoalContentRow } from '../../src/goal-content-helpers';
+
+// Mock validateSession
+jest.mock('../../src/auth-handlers', () => ({
+  validateSession: jest.fn(),
+}));
+
+jest.mock('../../src/journal-helpers', () => ({
+  hasUserReachedGoal: jest.fn(),
+  hasFellowshipReachedGoal: jest.fn(),
+  hasAnyFellowshipReachedGoal: jest.fn(),
+  isActivePartyMember: jest.fn(),
+}));
+
+jest.mock('../../src/admin-handlers', () => ({
+  logAdminAction: jest.fn(),
+}));
+
+import { validateSession } from '../../src/auth-handlers';
+import {
+  hasAnyFellowshipReachedGoal,
+  hasFellowshipReachedGoal,
+  hasUserReachedGoal,
+  isActivePartyMember,
+} from '../../src/journal-helpers';
+import { logAdminAction } from '../../src/admin-handlers';
+import {
+  handleAdminGoalContentCreate,
+  handleAdminGoalContentDelete,
+  handleAdminGoalContentList,
+  handleAdminGoalContentUpdate,
+  handleContentDiscoveryEvent,
+  handleGoalContentGet,
+} from '../../src/goal-content-handlers';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function mockDbClient(): { db: DbClient; mockDB: { prepare: jest.Mock } } {
+  const mockDB = { prepare: jest.fn() };
+  const db: DbClient = {
+    read: mockDB as unknown as D1Database,
+    write: mockDB as unknown as D1Database,
+  };
+  return { db, mockDB };
+}
+
+function mockFirst(mockDB: { prepare: jest.Mock }, value: unknown) {
+  mockDB.prepare.mockReturnValueOnce({
+    bind: jest.fn().mockReturnValue({
+      first: jest.fn(() => Promise.resolve(value)),
+    }),
+  });
+}
+
+function mockAll(mockDB: { prepare: jest.Mock }, results: unknown[]) {
+  mockDB.prepare.mockReturnValueOnce({
+    bind: jest.fn().mockReturnValue({
+      all: jest.fn(() => Promise.resolve({ results })),
+    }),
+  });
+}
+
+function mockRun(mockDB: { prepare: jest.Mock }, changes = 1, lastRowId?: number) {
+  mockDB.prepare.mockReturnValueOnce({
+    bind: jest.fn().mockReturnValue({
+      run: jest.fn(() => Promise.resolve({
+        meta: { changes, last_row_id: lastRowId ?? 0 },
+      })),
+    }),
+  });
+}
+
+function createRequest(path: string, headers?: Record<string, string>): Request {
+  return new Request(`https://example.com${path}`, {
+    headers: { 'Authorization': '******', ...headers },
+  });
+}
+
+function contentRow(overrides: Partial<GoalContentRow> = {}): GoalContentRow {
+  return {
+    id: 10,
+    goal_id: 5,
+    type: 'story',
+    title: 'Campfire tale',
+    body: 'Lore body',
+    author_attribution: 'Bilbo',
+    sort_order: 1,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-02T00:00:00Z',
+    ...overrides,
+  };
+}
+
+const validBody = {
+  type: 'story',
+  title: 'Campfire tale',
+  body: 'Lore body',
+  author_attribution: 'Bilbo',
+  sort_order: 1,
+};
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('Goal Content Handlers', () => {
+  let db: DbClient;
+  let mockDB: { prepare: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    console.error = jest.fn();
+    const client = mockDbClient();
+    db = client.db;
+    mockDB = client.mockDB;
+    (validateSession as jest.Mock).mockResolvedValue({ valid: true, userId: 1 });
+    (hasUserReachedGoal as jest.Mock).mockResolvedValue(false);
+    (hasFellowshipReachedGoal as jest.Mock).mockResolvedValue(false);
+    (hasAnyFellowshipReachedGoal as jest.Mock).mockResolvedValue(false);
+    (isActivePartyMember as jest.Mock).mockResolvedValue(false);
+    (logAdminAction as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  describe('admin CRUD handlers', () => {
+    it('lists content entries in stored order', async () => {
+      const rows = [
+        contentRow({ id: 1, title: 'First', sort_order: 0 }),
+        contentRow({ id: 2, title: 'Second', sort_order: 1 }),
+      ];
+      mockAll(mockDB, rows);
+
+      const resp = await handleAdminGoalContentList(createRequest('/api/admin/goals/5/content'), db, 5);
+      const data = await resp.json();
+
+      expect(resp.status).toBe(200);
+      expect(data.entries.map((entry: GoalContentRow) => entry.title)).toEqual(['First', 'Second']);
+      expect(mockDB.prepare.mock.calls[0][0]).toContain('ORDER BY sort_order ASC, id ASC');
+    });
+
+    it('returns 500 when list fails', async () => {
+      mockDB.prepare.mockImplementationOnce(() => {
+        throw new Error('D1 unavailable');
+      });
+
+      const resp = await handleAdminGoalContentList(createRequest('/api/admin/goals/5/content'), db, 5);
+      const data = await resp.json();
+
+      expect(resp.status).toBe(500);
+      expect(data.error).toContain('listing goal content');
+    });
+
+    it('creates content and logs the admin action', async () => {
+      mockFirst(mockDB, { id: 5 });
+      mockFirst(mockDB, null);
+      mockRun(mockDB, 1, 10);
+      mockFirst(mockDB, contentRow());
+
+      const resp = await handleAdminGoalContentCreate(
+        createRequest('/api/admin/goals/5/content', { 'CF-Connecting-IP': '203.0.113.1' }),
+        db,
+        5,
+        validBody,
+        99,
+      );
+      const data = await resp.json();
+
+      expect(resp.status).toBe(201);
+      expect(data.id).toBe(10);
+      expect(logAdminAction).toHaveBeenCalledWith(db, expect.objectContaining({
+        adminUserId: 99,
+        action: 'create_goal_content',
+        targetId: 10,
+        ipAddress: '203.0.113.1',
+        success: true,
+      }));
+    });
+
+    it('returns 404 when creating content for a missing goal', async () => {
+      mockFirst(mockDB, null);
+
+      const resp = await handleAdminGoalContentCreate(
+        createRequest('/api/admin/goals/404/content'),
+        db,
+        404,
+        validBody,
+        99,
+      );
+      const data = await resp.json();
+
+      expect(resp.status).toBe(404);
+      expect(data.error).toBe('Goal not found');
+      expect(logAdminAction).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when create validation fails', async () => {
+      mockFirst(mockDB, { id: 5 });
+
+      const resp = await handleAdminGoalContentCreate(
+        createRequest('/api/admin/goals/5/content'),
+        db,
+        5,
+        { ...validBody, type: 'song' },
+        99,
+      );
+      const data = await resp.json();
+
+      expect(resp.status).toBe(400);
+      expect(data.error).toContain('Type must be one of');
+      expect(logAdminAction).not.toHaveBeenCalled();
+    });
+
+    it('returns 409 when create hits duplicate sort order', async () => {
+      mockFirst(mockDB, { id: 5 });
+      mockFirst(mockDB, { id: 10 });
+
+      const resp = await handleAdminGoalContentCreate(
+        createRequest('/api/admin/goals/5/content'),
+        db,
+        5,
+        validBody,
+        99,
+      );
+      const data = await resp.json();
+
+      expect(resp.status).toBe(409);
+      expect(data.error).toContain('sort order already exists');
+      expect(logAdminAction).not.toHaveBeenCalled();
+    });
+
+    it('returns 200 when update succeeds', async () => {
+      mockFirst(mockDB, contentRow());
+      mockFirst(mockDB, contentRow());
+      mockFirst(mockDB, null);
+      mockRun(mockDB, 1);
+      mockFirst(mockDB, contentRow({ title: 'Updated', sort_order: 2 }));
+
+      const resp = await handleAdminGoalContentUpdate(
+        createRequest('/api/admin/goals/5/content/10'),
+        db,
+        5,
+        10,
+        { ...validBody, title: 'Updated', sort_order: 2 },
+        99,
+      );
+      const data = await resp.json();
+
+      expect(resp.status).toBe(200);
+      expect(data.title).toBe('Updated');
+      expect(logAdminAction).toHaveBeenCalledWith(db, expect.objectContaining({
+        action: 'update_goal_content',
+        targetId: 10,
+      }));
+    });
+
+    it('returns 404 when update target is missing', async () => {
+      mockFirst(mockDB, null);
+
+      const resp = await handleAdminGoalContentUpdate(
+        createRequest('/api/admin/goals/5/content/404'),
+        db,
+        5,
+        404,
+        validBody,
+        99,
+      );
+
+      expect(resp.status).toBe(404);
+      expect(logAdminAction).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when update target belongs to another goal', async () => {
+      mockFirst(mockDB, contentRow({ goal_id: 6 }));
+
+      const resp = await handleAdminGoalContentUpdate(
+        createRequest('/api/admin/goals/5/content/10'),
+        db,
+        5,
+        10,
+        validBody,
+        99,
+      );
+
+      expect(resp.status).toBe(404);
+      expect(logAdminAction).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when update validation fails', async () => {
+      mockFirst(mockDB, contentRow());
+
+      const resp = await handleAdminGoalContentUpdate(
+        createRequest('/api/admin/goals/5/content/10'),
+        db,
+        5,
+        10,
+        { ...validBody, title: '   ' },
+        99,
+      );
+
+      expect(resp.status).toBe(400);
+      expect(logAdminAction).not.toHaveBeenCalled();
+    });
+
+    it('returns 409 when update hits duplicate sort order', async () => {
+      mockFirst(mockDB, contentRow());
+      mockFirst(mockDB, contentRow());
+      mockFirst(mockDB, { id: 11 });
+
+      const resp = await handleAdminGoalContentUpdate(
+        createRequest('/api/admin/goals/5/content/10'),
+        db,
+        5,
+        10,
+        validBody,
+        99,
+      );
+      const data = await resp.json();
+
+      expect(resp.status).toBe(409);
+      expect(data.error).toContain('sort order already exists');
+      expect(logAdminAction).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 if update helper cannot refetch the entry', async () => {
+      mockFirst(mockDB, contentRow());
+      mockFirst(mockDB, null);
+
+      const resp = await handleAdminGoalContentUpdate(
+        createRequest('/api/admin/goals/5/content/10'),
+        db,
+        5,
+        10,
+        validBody,
+        99,
+      );
+
+      expect(resp.status).toBe(404);
+    });
+
+    it('deletes content and logs the admin action', async () => {
+      mockFirst(mockDB, contentRow());
+      mockRun(mockDB, 1);
+
+      const resp = await handleAdminGoalContentDelete(
+        createRequest('/api/admin/goals/5/content/10'),
+        db,
+        5,
+        10,
+        99,
+      );
+      const data = await resp.json();
+
+      expect(resp.status).toBe(200);
+      expect(data.message).toBe('Goal content deleted');
+      expect(logAdminAction).toHaveBeenCalledWith(db, expect.objectContaining({
+        action: 'delete_goal_content',
+        targetId: 10,
+      }));
+    });
+
+    it('returns 404 when delete target is missing', async () => {
+      mockFirst(mockDB, null);
+
+      const resp = await handleAdminGoalContentDelete(
+        createRequest('/api/admin/goals/5/content/404'),
+        db,
+        5,
+        404,
+        99,
+      );
+
+      expect(resp.status).toBe(404);
+      expect(logAdminAction).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when delete target belongs to another goal', async () => {
+      mockFirst(mockDB, contentRow({ goal_id: 6 }));
+
+      const resp = await handleAdminGoalContentDelete(
+        createRequest('/api/admin/goals/5/content/10'),
+        db,
+        5,
+        10,
+        99,
+      );
+
+      expect(resp.status).toBe(404);
+      expect(logAdminAction).not.toHaveBeenCalled();
+    });
+
+    it('returns 500 when delete fails', async () => {
+      mockFirst(mockDB, contentRow());
+      mockDB.prepare.mockImplementationOnce(() => {
+        throw new Error('D1 unavailable');
+      });
+
+      const resp = await handleAdminGoalContentDelete(
+        createRequest('/api/admin/goals/5/content/10'),
+        db,
+        5,
+        10,
+        99,
+      );
+
+      expect(resp.status).toBe(500);
+    });
+  });
+
+  describe('public goal-content reads', () => {
+    it('returns entries when personal progress unlocks the goal', async () => {
+      (hasUserReachedGoal as jest.Mock).mockResolvedValue(true);
+      mockAll(mockDB, [contentRow()]);
+
+      const resp = await handleGoalContentGet(createRequest('/api/goals/5/content'), db, 5);
+      const data = await resp.json();
+
+      expect(resp.status).toBe(200);
+      expect(data.entries).toHaveLength(1);
+      expect(hasUserReachedGoal).toHaveBeenCalledWith(db, 1, 5);
+      expect(hasAnyFellowshipReachedGoal).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when all unlock checks fail', async () => {
+      const resp = await handleGoalContentGet(createRequest('/api/goals/5/content'), db, 5);
+      const data = await resp.json();
+
+      expect(resp.status).toBe(403);
+      expect(data.error).toBe('This goal content is locked');
+      expect(hasAnyFellowshipReachedGoal).toHaveBeenCalledWith(db, 1, 5);
+    });
+
+    it('returns 403 when partyId viewer is not an active member', async () => {
+      const resp = await handleGoalContentGet(createRequest('/api/goals/5/content?partyId=99'), db, 5);
+      const data = await resp.json();
+
+      expect(resp.status).toBe(403);
+      expect(data.error).toContain('not an active member');
+      expect(isActivePartyMember).toHaveBeenCalledWith(db, 1, 99);
+      expect(hasUserReachedGoal).not.toHaveBeenCalled();
+    });
+
+    it('rejects invalid partyId', async () => {
+      const resp = await handleGoalContentGet(createRequest('/api/goals/5/content?partyId=abc'), db, 5);
+      const data = await resp.json();
+
+      expect(resp.status).toBe(400);
+      expect(data.error).toBe('Invalid partyId');
+    });
+
+    it('returns entries when fellowship progress unlocks the goal', async () => {
+      (isActivePartyMember as jest.Mock).mockResolvedValue(true);
+      (hasFellowshipReachedGoal as jest.Mock).mockResolvedValue(true);
+      mockAll(mockDB, [contentRow()]);
+
+      const resp = await handleGoalContentGet(createRequest('/api/goals/5/content?partyId=99'), db, 5);
+      const data = await resp.json();
+
+      expect(resp.status).toBe(200);
+      expect(data.entries).toHaveLength(1);
+      expect(hasUserReachedGoal).toHaveBeenCalledWith(db, 1, 5);
+      expect(hasFellowshipReachedGoal).toHaveBeenCalledWith(db, 99, 5);
+    });
+
+    it('returns entries when any fellowship unlocks without partyId', async () => {
+      (hasAnyFellowshipReachedGoal as jest.Mock).mockResolvedValue(true);
+      mockAll(mockDB, [contentRow({ id: 11 })]);
+
+      const resp = await handleGoalContentGet(createRequest('/api/goals/5/content'), db, 5);
+      const data = await resp.json();
+
+      expect(resp.status).toBe(200);
+      expect(data.entries[0].id).toBe(11);
+    });
+
+    it('returns an empty list when unlocked goal has no entries', async () => {
+      (hasUserReachedGoal as jest.Mock).mockResolvedValue(true);
+      mockAll(mockDB, []);
+
+      const resp = await handleGoalContentGet(createRequest('/api/goals/5/content'), db, 5);
+      const data = await resp.json();
+
+      expect(resp.status).toBe(200);
+      expect(data.entries).toEqual([]);
+    });
+
+    it('returns the validation error for unauthenticated reads', async () => {
+      (validateSession as jest.Mock).mockResolvedValue({
+        valid: false,
+        error: new Response(JSON.stringify({ error: 'Unauthorized' }), {
+          status: 401,
+          headers: { 'content-type': 'application/json' },
+        }),
+      });
+
+      const resp = await handleGoalContentGet(createRequest('/api/goals/5/content'), db, 5);
+
+      expect(resp.status).toBe(401);
+    });
+
+    it('returns 500 when unlocked content read fails', async () => {
+      (hasUserReachedGoal as jest.Mock).mockResolvedValue(true);
+      mockDB.prepare.mockImplementationOnce(() => {
+        throw new Error('D1 unavailable');
+      });
+
+      const resp = await handleGoalContentGet(createRequest('/api/goals/5/content'), db, 5);
+
+      expect(resp.status).toBe(500);
+    });
+  });
+
+  describe('discovery events', () => {
+    it('rejects invalid event_type', async () => {
+      const resp = await handleContentDiscoveryEvent(
+        createRequest('/api/goals/5/content/events'),
+        db,
+        5,
+        { event_type: 'bad', context_type: 'personal' },
+        jest.fn(),
+      );
+      const data = await resp.json();
+
+      expect(resp.status).toBe(400);
+      expect(data.error).toBe('Invalid event_type');
+    });
+
+    it('rejects invalid context_type', async () => {
+      const resp = await handleContentDiscoveryEvent(
+        createRequest('/api/goals/5/content/events'),
+        db,
+        5,
+        { event_type: 'content_open', context_type: 'bad' },
+        jest.fn(),
+      );
+      const data = await resp.json();
+
+      expect(resp.status).toBe(400);
+      expect(data.error).toBe('Invalid context_type');
+    });
+
+    it('schedules valid discovery events and returns 202', async () => {
+      const scheduleBackground = jest.fn();
+      mockRun(mockDB, 1);
+
+      const resp = await handleContentDiscoveryEvent(
+        createRequest('/api/goals/5/content/events'),
+        db,
+        5,
+        {
+          event_type: 'content_open',
+          context_type: 'fellowship',
+          partyId: 99,
+          content_id: 10,
+        },
+        scheduleBackground,
+      );
+      const data = await resp.json();
+
+      expect(resp.status).toBe(202);
+      expect(data.accepted).toBe(true);
+      expect(scheduleBackground).toHaveBeenCalledWith(expect.any(Promise));
+      await scheduleBackground.mock.calls[0][0];
+    });
+
+    it('returns the validation error for unauthenticated event writes', async () => {
+      (validateSession as jest.Mock).mockResolvedValue({
+        valid: false,
+        error: new Response(JSON.stringify({ error: 'Unauthorized' }), {
+          status: 401,
+          headers: { 'content-type': 'application/json' },
+        }),
+      });
+
+      const resp = await handleContentDiscoveryEvent(
+        createRequest('/api/goals/5/content/events'),
+        db,
+        5,
+        { event_type: 'content_open', context_type: 'personal' },
+        jest.fn(),
+      );
+
+      expect(resp.status).toBe(401);
+    });
+  });
+});

--- a/tests/api/goal-content-helpers.test.ts
+++ b/tests/api/goal-content-helpers.test.ts
@@ -1,0 +1,280 @@
+import {
+  GOAL_CONTENT_LIMITS,
+  DuplicateSortOrderError,
+  createGoalContent,
+  deleteGoalContent,
+  goalHasContent,
+  listGoalContent,
+  recordDiscoveryEvent,
+  updateGoalContent,
+  validateGoalContentInput,
+  type GoalContentInput,
+  type GoalContentRow,
+} from '../../src/goal-content-helpers';
+import { DbClient } from '../../src/db';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function mockDbClient(): { db: DbClient; mockDB: { prepare: jest.Mock } } {
+  const mockDB = { prepare: jest.fn() };
+  const db: DbClient = {
+    read: mockDB as unknown as D1Database,
+    write: mockDB as unknown as D1Database,
+  };
+  return { db, mockDB };
+}
+
+function mockFirst(mockDB: { prepare: jest.Mock }, value: unknown) {
+  mockDB.prepare.mockReturnValueOnce({
+    bind: jest.fn().mockReturnValue({
+      first: jest.fn(() => Promise.resolve(value)),
+    }),
+  });
+}
+
+function mockAll(mockDB: { prepare: jest.Mock }, results: unknown[]) {
+  mockDB.prepare.mockReturnValueOnce({
+    bind: jest.fn().mockReturnValue({
+      all: jest.fn(() => Promise.resolve({ results })),
+    }),
+  });
+}
+
+function mockRun(mockDB: { prepare: jest.Mock }, changes = 1, lastRowId?: number) {
+  mockDB.prepare.mockReturnValueOnce({
+    bind: jest.fn().mockReturnValue({
+      run: jest.fn(() => Promise.resolve({
+        meta: { changes, last_row_id: lastRowId ?? 0 },
+      })),
+    }),
+  });
+}
+
+const validInput: GoalContentInput = {
+  type: 'story',
+  title: 'At the Campfire',
+  body: 'A tale from the road.',
+  author_attribution: 'Bilbo',
+  sort_order: 2,
+};
+
+function goalContentRow(overrides: Partial<GoalContentRow> = {}): GoalContentRow {
+  return {
+    id: 10,
+    goal_id: 5,
+    type: 'story',
+    title: 'At the Campfire',
+    body: 'A tale from the road.',
+    author_attribution: 'Bilbo',
+    sort_order: 2,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-02T00:00:00Z',
+    ...overrides,
+  };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('Goal Content Helpers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    console.error = jest.fn();
+  });
+
+  describe('validateGoalContentInput', () => {
+    it('accepts valid content, trims text fields, and normalizes blank attribution', () => {
+      const result = validateGoalContentInput({
+        type: 'appendix',
+        title: '  Lore Notes  ',
+        body: '  Body stays authored.  ',
+        author_attribution: '   ',
+        sort_order: 0,
+      });
+
+      expect(result).toEqual({
+        ok: true,
+        value: {
+          type: 'appendix',
+          title: 'Lore Notes',
+          body: '  Body stays authored.  ',
+          author_attribution: null,
+          sort_order: 0,
+        },
+      });
+    });
+
+    it('trims non-empty attribution', () => {
+      const result = validateGoalContentInput({
+        ...validInput,
+        author_attribution: '  Bilbo Baggins  ',
+      });
+
+      expect(result).toEqual({
+        ok: true,
+        value: {
+          ...validInput,
+          author_attribution: 'Bilbo Baggins',
+        },
+      });
+    });
+
+    it.each([
+      ['invalid request body', null, 'Invalid request body'],
+      ['invalid type', { ...validInput, type: 'song' }, 'Type must be one of'],
+      ['missing title', { ...validInput, title: '   ' }, 'Title is required'],
+      [
+        'title too long',
+        { ...validInput, title: 'x'.repeat(GOAL_CONTENT_LIMITS.TITLE_MAX + 1) },
+        'Title must be 120 characters or less',
+      ],
+      ['missing body', { ...validInput, body: '   ' }, 'Body is required'],
+      [
+        'body too long',
+        { ...validInput, body: 'x'.repeat(GOAL_CONTENT_LIMITS.BODY_MAX + 1) },
+        'Body must be 20000 characters or less',
+      ],
+      [
+        'attribution too long',
+        { ...validInput, author_attribution: 'x'.repeat(GOAL_CONTENT_LIMITS.ATTRIBUTION_MAX + 1) },
+        'Attribution must be 255 characters or less',
+      ],
+      ['non-string attribution', { ...validInput, author_attribution: 123 }, 'Attribution must be a string'],
+      ['non-integer sort order', { ...validInput, sort_order: 1.5 }, 'Sort order must be an integer'],
+      ['sort order below range', { ...validInput, sort_order: -1 }, 'Sort order must be between 0 and 999'],
+      ['sort order above range', { ...validInput, sort_order: 1000 }, 'Sort order must be between 0 and 999'],
+    ])('rejects %s', (_name, body, expectedError) => {
+      const result = validateGoalContentInput(body);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain(expectedError);
+      }
+    });
+  });
+
+  describe('data access', () => {
+    let db: DbClient;
+    let mockDB: { prepare: jest.Mock };
+
+    beforeEach(() => {
+      const client = mockDbClient();
+      db = client.db;
+      mockDB = client.mockDB;
+    });
+
+    it('lists goal content using ordered persistence', async () => {
+      const rows = [
+        goalContentRow({ id: 1, sort_order: 0, title: 'First' }),
+        goalContentRow({ id: 2, sort_order: 1, title: 'Second' }),
+      ];
+      mockAll(mockDB, rows);
+
+      const entries = await listGoalContent(db, 5);
+
+      expect(entries.map((entry) => entry.title)).toEqual(['First', 'Second']);
+      expect(mockDB.prepare.mock.calls[0][0]).toContain('ORDER BY sort_order ASC, id ASC');
+    });
+
+    it('creates content after checking duplicate sort order', async () => {
+      const createdRow = goalContentRow({ id: 44 });
+      mockFirst(mockDB, null);
+      mockRun(mockDB, 1, 44);
+      mockFirst(mockDB, createdRow);
+
+      const created = await createGoalContent(db, 5, validInput);
+
+      expect(created).toEqual(createdRow);
+      expect(mockDB.prepare).toHaveBeenCalledTimes(3);
+    });
+
+    it('rejects duplicate sort order on create', async () => {
+      mockFirst(mockDB, { id: 99 });
+
+      await expect(createGoalContent(db, 5, validInput)).rejects.toBeInstanceOf(DuplicateSortOrderError);
+      expect(mockDB.prepare).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws if created row cannot be fetched', async () => {
+      mockFirst(mockDB, null);
+      mockRun(mockDB, 1, 44);
+      mockFirst(mockDB, null);
+
+      await expect(createGoalContent(db, 5, validInput)).rejects.toThrow('Failed to fetch created goal content');
+    });
+
+    it('updates content after checking duplicate sort order', async () => {
+      const existing = goalContentRow();
+      const updated = goalContentRow({ title: 'Updated title', sort_order: 3 });
+      mockFirst(mockDB, existing);
+      mockFirst(mockDB, null);
+      mockRun(mockDB, 1);
+      mockFirst(mockDB, updated);
+
+      const result = await updateGoalContent(db, 10, { ...validInput, title: 'Updated title', sort_order: 3 });
+
+      expect(result).toEqual(updated);
+      expect(mockDB.prepare).toHaveBeenCalledTimes(4);
+    });
+
+    it('returns null when updating a missing entry', async () => {
+      mockFirst(mockDB, null);
+
+      await expect(updateGoalContent(db, 404, validInput)).resolves.toBeNull();
+      expect(mockDB.prepare).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects duplicate sort order on update', async () => {
+      mockFirst(mockDB, goalContentRow());
+      mockFirst(mockDB, { id: 11 });
+
+      await expect(updateGoalContent(db, 10, validInput)).rejects.toBeInstanceOf(DuplicateSortOrderError);
+    });
+
+    it('deletes content and reports whether a row changed', async () => {
+      mockRun(mockDB, 1);
+      await expect(deleteGoalContent(db, 10)).resolves.toBe(true);
+
+      mockRun(mockDB, 0);
+      await expect(deleteGoalContent(db, 11)).resolves.toBe(false);
+    });
+
+    it('checks whether a goal has content', async () => {
+      mockFirst(mockDB, { present: 1 });
+      await expect(goalHasContent(db, 5)).resolves.toBe(true);
+
+      mockFirst(mockDB, null);
+      await expect(goalHasContent(db, 6)).resolves.toBe(false);
+    });
+
+    it('records discovery events', async () => {
+      mockRun(mockDB, 1);
+
+      await recordDiscoveryEvent(db, {
+        userId: 1,
+        partyId: 2,
+        goalId: 5,
+        contentId: 10,
+        eventType: 'content_open',
+        contextType: 'fellowship',
+      });
+
+      expect(mockDB.prepare).toHaveBeenCalledTimes(1);
+    });
+
+    it('swallows discovery event database failures', async () => {
+      mockDB.prepare.mockImplementationOnce(() => {
+        throw new Error('D1 unavailable');
+      });
+
+      await expect(recordDiscoveryEvent(db, {
+        userId: 1,
+        partyId: null,
+        goalId: 5,
+        contentId: null,
+        eventType: 'teaser_impression',
+        contextType: 'personal',
+      })).resolves.toBeUndefined();
+      expect(console.error).toHaveBeenCalledWith('Failed to record content discovery event:', expect.any(Error));
+    });
+  });
+});

--- a/tests/api/goals-handlers.test.ts
+++ b/tests/api/goals-handlers.test.ts
@@ -21,8 +21,8 @@ describe('Goals Handlers', () => {
   describe('handleGoalsGet', () => {
     it('should return goals successfully', async () => {
       const mockResults = [
-        { storyline_goal_id: 10, id: 1, distance: 100, title: 'Rivendell', description: null, special: true, image_id: '1', sort_order: 1 },
-        { storyline_goal_id: 11, id: 2, distance: 200, title: 'Lothlorien', description: null, special: false, image_id: '2', sort_order: 2 }
+        { storyline_goal_id: 10, id: 1, distance: 100, title: 'Rivendell', description: null, special: true, image_id: '1', sort_order: 1, has_content: false },
+        { storyline_goal_id: 11, id: 2, distance: 200, title: 'Lothlorien', description: null, special: false, image_id: '2', sort_order: 2, has_content: false }
       ];
 
       // Mock session validation
@@ -127,7 +127,7 @@ describe('Goals Handlers', () => {
 
     it('should use explicit storylineId when provided as query param', async () => {
       const mockResults = [
-        { storyline_goal_id: 20, id: 3, distance: 300, title: 'Edoras', description: null, special: false, image_id: null, sort_order: 1 },
+        { storyline_goal_id: 20, id: 3, distance: 300, title: 'Edoras', description: null, special: false, image_id: null, sort_order: 1, has_content: false },
       ];
 
       // Mock session validation

--- a/tests/ui/goal-content.spec.js
+++ b/tests/ui/goal-content.spec.js
@@ -1,0 +1,198 @@
+// @ts-check
+const { test: base, expect } = require('@playwright/test');
+const { cleanupAllTestData } = require('./helpers/cleanup');
+
+const BASE_URL = process.env.TEST_BASE_URL || 'http://127.0.0.1:8787';
+
+function uniqueId() {
+  return Math.random().toString(36).substring(2, 8);
+}
+
+/**
+ * Auth fixtures. Mock-token users are non-admin by default and there is no
+ * admin-grant API, so admin authoring flows are exercised through their
+ * access-control contract (401/403) while user-facing unlock semantics are
+ * exercised end-to-end via the public goal-content API.
+ */
+const test = base.extend({
+  adminToken: async ({}, use) => {
+    const token = `TEST_MOCK_TOKEN_ContentAdminE2E_${uniqueId()}`;
+    await use(token);
+    await cleanupAllTestData(BASE_URL, token);
+  },
+  regularToken: async ({}, use) => {
+    const token = `TEST_MOCK_TOKEN_ContentRegularE2E_${uniqueId()}`;
+    await use(token);
+    await cleanupAllTestData(BASE_URL, token);
+  },
+});
+
+function auth(token) {
+  return { Authorization: `Bearer ${token}` };
+}
+
+async function ensureUserExists(request, token) {
+  const response = await request.get(`${BASE_URL}/api/session`, {
+    headers: auth(token),
+  });
+  expect(response.ok(), `Failed to create user: ${await response.text()}`).toBeTruthy();
+  return response.json();
+}
+
+async function getGoals(request, token) {
+  const response = await request.get(`${BASE_URL}/api/goals`, { headers: auth(token) });
+  expect(response.ok(), `Failed to load goals: ${await response.text()}`).toBeTruthy();
+  return response.json();
+}
+
+async function logDistance(request, token, distance) {
+  const today = new Date().toISOString().split('T')[0];
+  return request.post(`${BASE_URL}/api/calendar-progress`, {
+    data: { start: today, title: String(distance) },
+    headers: auth(token),
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Admin goal-content authoring — access control contract
+// ═══════════════════════════════════════════════════════════════════════════
+
+test.describe('Goal Content - Admin Access Control', () => {
+  test('unauthenticated user gets 401 for admin goal-content endpoints', async ({ request }) => {
+    const list = await request.get(`${BASE_URL}/api/admin/goals/1/content`);
+    expect(list.status()).toBe(401);
+
+    const create = await request.post(`${BASE_URL}/api/admin/goals/1/content`, {
+      data: { type: 'story', title: 'X', body: 'Y', sort_order: 0 },
+    });
+    expect(create.status()).toBe(401);
+  });
+
+  test('non-admin user gets 403 for admin goal-content endpoints', async ({ request, regularToken }) => {
+    await ensureUserExists(request, regularToken);
+
+    const list = await request.get(`${BASE_URL}/api/admin/goals/1/content`, {
+      headers: auth(regularToken),
+    });
+    expect(list.status()).toBe(403);
+
+    const create = await request.post(`${BASE_URL}/api/admin/goals/1/content`, {
+      headers: auth(regularToken),
+      data: { type: 'story', title: 'X', body: 'Y', sort_order: 0 },
+    });
+    expect(create.status()).toBe(403);
+
+    const update = await request.put(`${BASE_URL}/api/admin/goals/1/content/1`, {
+      headers: auth(regularToken),
+      data: { type: 'story', title: 'X', body: 'Y', sort_order: 0 },
+    });
+    expect(update.status()).toBe(403);
+
+    const del = await request.delete(`${BASE_URL}/api/admin/goals/1/content/1`, {
+      headers: auth(regularToken),
+    });
+    expect(del.status()).toBe(403);
+  });
+
+  test('admin goal edit page returns an HTML shell for browser navigation', async ({ request }) => {
+    const response = await request.get(`${BASE_URL}/admin/goals/1`);
+    expect(response.status()).toBe(200);
+    const contentType = response.headers()['content-type'] || '';
+    expect(contentType).toContain('text/html');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Public goal-content — content-presence and locked/unlocked flows
+// ═══════════════════════════════════════════════════════════════════════════
+
+test.describe('Goal Content - Public Read Flows', () => {
+  test('GET /api/goals includes has_content boolean on every goal', async ({ request, regularToken }) => {
+    await ensureUserExists(request, regularToken);
+    const goals = await getGoals(request, regularToken);
+
+    expect(Array.isArray(goals)).toBeTruthy();
+    expect(goals.length).toBeGreaterThan(0);
+    for (const goal of goals) {
+      expect(goal).toHaveProperty('has_content');
+      expect(typeof goal.has_content).toBe('boolean');
+    }
+  });
+
+  test('locked goal content returns 403 for a fresh user', async ({ request, regularToken }) => {
+    await ensureUserExists(request, regularToken);
+    const goals = await getGoals(request, regularToken);
+
+    // Fresh user has zero distance; the furthest goal is guaranteed locked.
+    const furthest = goals.reduce((max, g) => (g.distance > max.distance ? g : max), goals[0]);
+
+    const response = await request.get(`${BASE_URL}/api/goals/${furthest.id}/content`, {
+      headers: auth(regularToken),
+    });
+    expect(response.status()).toBe(403);
+    const body = await response.json();
+    expect(body).toHaveProperty('error');
+  });
+
+  test('unlocked goal content returns 200 with an entries array', async ({ request, regularToken }) => {
+    await ensureUserExists(request, regularToken);
+    const goals = await getGoals(request, regularToken);
+
+    // Unlock the nearest goal by logging enough distance to pass it.
+    const nearest = goals.reduce((min, g) => (g.distance < min.distance ? g : min), goals[0]);
+    const logResp = await logDistance(request, regularToken, Math.ceil(nearest.distance) + 5);
+    expect(logResp.ok(), `Failed to log distance: ${await logResp.text()}`).toBeTruthy();
+
+    const response = await request.get(`${BASE_URL}/api/goals/${nearest.id}/content`, {
+      headers: auth(regularToken),
+    });
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body).toHaveProperty('entries');
+    expect(Array.isArray(body.entries)).toBeTruthy();
+  });
+
+  test('invalid goalId returns 400', async ({ request, regularToken }) => {
+    await ensureUserExists(request, regularToken);
+    const response = await request.get(`${BASE_URL}/api/goals/abc/content`, {
+      headers: auth(regularToken),
+    });
+    expect(response.status()).toBe(400);
+  });
+
+  test('goal content read requires authentication', async ({ request }) => {
+    const response = await request.get(`${BASE_URL}/api/goals/1/content`);
+    expect(response.status()).toBe(401);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Discovery analytics — best-effort event recording
+// ═══════════════════════════════════════════════════════════════════════════
+
+test.describe('Goal Content - Discovery Analytics', () => {
+  test('valid discovery event is accepted (202)', async ({ request, regularToken }) => {
+    await ensureUserExists(request, regularToken);
+    const response = await request.post(`${BASE_URL}/api/goals/1/content/events`, {
+      headers: auth(regularToken),
+      data: { event_type: 'teaser_impression', context_type: 'personal' },
+    });
+    expect(response.status()).toBe(202);
+  });
+
+  test('invalid event_type is rejected (400)', async ({ request, regularToken }) => {
+    await ensureUserExists(request, regularToken);
+    const response = await request.post(`${BASE_URL}/api/goals/1/content/events`, {
+      headers: auth(regularToken),
+      data: { event_type: 'nope', context_type: 'personal' },
+    });
+    expect(response.status()).toBe(400);
+  });
+
+  test('discovery event requires authentication (401)', async ({ request }) => {
+    const response = await request.post(`${BASE_URL}/api/goals/1/content/events`, {
+      data: { event_type: 'content_open', context_type: 'personal' },
+    });
+    expect(response.status()).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the `goal-content-campfire-lore` OpenSpec change — a fully gated campfire lore system for goals.

### Features
- **D1 tables**: `goal_content` (story/poetry/appendix entries) + `content_discovery_events` (analytics)
- **Admin CRUD**: full create/edit/delete UI on the goal edit page with markdown preview, sort order management, type labels
- **Public read**: `GET /api/goals/:id/content` — 403 if goal not yet reached by distance, 200 with entries array once unlocked
- **`has_content` flag** on every `/api/goals` response item
- **GoalModal**: collapsible 🔥 Campfire Lore panel — collapsed by default, summary line shows count per type (each on its own line for mobile), expands to show all entries
- **Discovery analytics**: `POST /api/goals/:id/content/events` — 202 accepted, best-effort

### Bug fixes
- Admin page h3/h4+ headings were black-on-black (inherited browser default). Fixed via `color: var(--text-primary)` on `body` in `main.css`.

### Admin UX polish
- Sort order defaults to `max(existing) + 1`
- Sort order help text no longer mentions 409 API errors
- "Back to Goals" button moved to bottom of page (below content management)
- Campfire lore summary items each on own line in header (mobile-friendly)

### Tests
- 818 client (Vitest) tests passing
- New Playwright spec: `tests/ui/goal-content.spec.js` (access control, locked/unlocked flows, analytics)
- New API unit tests: `goal-content-handlers.test.ts`, `goal-content-helpers.test.ts`