### PR TITLE
chore(deps): ignore wrangler 4.114.0-4.125.x in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,15 @@ updates:
     # ignore:
     #   - dependency-name: "package-name"
     #     versions: ["x.x.x"]
+
+    # wrangler 4.114.0-4.125.x contains a regression where wrangler dev
+    # fatally exits on a recoverable workerd crash, killing the E2E
+    # webServer (cloudflare/workers-sdk#14926). Pinned to 4.113.0 in
+    # package.json; ignore only the broken window so releases with the
+    # fix (4.126.0+, workers-sdk#15252) are still proposed.
+    ignore:
+      - dependency-name: "wrangler"
+        versions: [">=4.114.0 <4.126.0"]
   
   # GitHub Actions dependencies
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Scoped dependabot `ignore` for the known-bad wrangler window:

- wrangler >=4.114.0 carries a dev-server fatal-exit regression ([workers-sdk#14926](https://github.com/cloudflare/workers-sdk/issues/14926)) that kills the E2E webServer mid-run (seen twice in CI: #496 original + recreated).
- package.json is pinned to exactly `4.113.0` (#497).
- This rule ignores only `>=4.114.0 <4.126.0`, so once upstream ships the fix via #15252 (expected 4.126.0+), Dependabot will propose it normally — no blanket block, no manual unignore needed.

Also closes out #496's repeated failure: after this merges, `@dependabot recreate` on #496 regenerates the dev-deps group PR with wrangler excluded.